### PR TITLE
Update Package versions + disable guardrails in demo-setup

### DIFF
--- a/cli
+++ b/cli
@@ -96,11 +96,9 @@ program
     try {
       await utils.terraform.applyWithRetry(TERRAFORM_DIR, 3);
       const installItems = async (items, ITEMS_DIR, itemKey) => {
-        const itemPaths = items
-          .filter(item => item[itemKey] !== 'disabled')
-          .map((item) => {
-            return path.join(ITEMS_DIR, item.category, item[itemKey], "index.mjs");
-          });
+        const itemPaths = items.map((item) => {
+          return path.join(ITEMS_DIR, item.category, item[itemKey], "index.mjs");
+        });
         for (const itemPath of itemPaths) {
           const itemModule = await import(itemPath);
           await itemModule.init(DIR, config, utils);

--- a/config.json
+++ b/config.json
@@ -6,8 +6,7 @@
       { "category": "gui-app", "component": "openwebui" },
       { "category": "vector-database", "component": "qdrant" },
       { "category": "embedding-model", "component": "tei" },
-      { "category": "ai-gateway", "component": "litellm" },
-      { "category": "guardrail", "component": "disabled" }
+      { "category": "ai-gateway", "component": "litellm" }
     ],
     "examples": [
       { "category": "mcp-server", "example": "calculator" },


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* 

Update Package Versions in Dockerfile requirements.
- Unable to currently upgrade flask-cors to 6.0.0, due to version incompatability with latest version of guardrails package


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
