### PR TITLE
chore: update Bedrock models with Claude 4.5 and Nova 2

### DIFF
--- a/config.json
+++ b/config.json
@@ -72,12 +72,10 @@
     "llm": {
       "models": [
         { "name": "amazon-nova-premier", "model": "us.amazon.nova-premier-v1:0" },
-        { "name": "amazon-nova-2-lite-global", "model": "global.amazon.nova-2-lite-v1:0" },
-        { "name": "claude-opus-4.5", "model": "global.anthropic.claude-opus-4-5-20251101-v1:0" },
-        { "name": "claude-sonnet-4.5-global", "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0" },
-        { "name": "claude-haiku-4.5-global", "model": "global.anthropic.claude-haiku-4-5-20251001-v1:0" },
-        { "name": "claude-4-opus", "model": "us.anthropic.claude-opus-4-20250514-v1:0" },
-        { "name": "claude-4-sonnet", "model": "us.anthropic.claude-sonnet-4-20250514-v1:0" },
+        { "name": "amazon-nova-2-lite", "model": "global.amazon.nova-2-lite-v1:0" },
+        { "name": "claude-4.5-opus", "model": "global.anthropic.claude-opus-4-5-20251101-v1:0" },
+        { "name": "claude-4.5-sonnet", "model": "global.anthropic.claude-sonnet-4-5-20250929-v1:0" },
+        { "name": "claude-4.5-haiku", "model": "global.anthropic.claude-haiku-4-5-20251001-v1:0" },
         { "name": "llama4-maverick", "model": "us.meta.llama4-maverick-17b-instruct-v1:0" },
         { "name": "llama4-scout", "model": "us.meta.llama4-scout-17b-instruct-v1:0" }
       ]


### PR DESCRIPTION
## Summary
- Add Claude 4.5 models (Opus, Sonnet, Haiku) with global CRIS
- Add Amazon Nova 2 Lite model (global CRIS)
- Remove Claude 3.7 Sonnet (superseded by 4.5)
- Fix: Opus 4.5 only supports global CRIS (no US CRIS available)

## Models Added
| Model | Bedrock ID |
|-------|------------|
| claude-opus-4.5 | global.anthropic.claude-opus-4-5-20251101-v1:0 |
| claude-sonnet-4.5-global | global.anthropic.claude-sonnet-4-5-20250929-v1:0 |
| claude-haiku-4.5-global | global.anthropic.claude-haiku-4-5-20251001-v1:0 |
| amazon-nova-2-lite-global | global.amazon.nova-2-lite-v1:0 |

## Test plan
- [x] Reinstall LiteLLM: `./cli ai-gateway litellm install`
- [x] Verify models appear in OpenWebUI 
<img width="515" height="362" alt="image" src="https://github.com/user-attachments/assets/a859a889-076a-428f-ab2d-d6f0c0b6fb4c" />

- [x] Test chat with each new model
- [x] Verify models are called in LiteLLM