### PR TITLE
fix to main-v1.81.3-stable

### DIFF
--- a/components/ai-gateway/litellm/values.template.yaml
+++ b/components/ai-gateway/litellm/values.template.yaml
@@ -1,3 +1,6 @@
+image:
+  tag: main-v1.81.3-stable
+
 global:
   security:
     # -- Allow insecure images to use our ECR images.


### PR DESCRIPTION
*Issue #, if available:* LiteLLM failing due to main-v1.81.3 not existing in GHCR only in Docker

*Description of changes:* Fixed version to main-v1.81.3-stable. This way future changes will not affect helm chart deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
