### PR TITLE
Removed reuseaccesspoint from SC in EKS Standard Mode

### DIFF
--- a/terraform/modules/eks-standard-mode/eks-addons.tf
+++ b/terraform/modules/eks-standard-mode/eks-addons.tf
@@ -632,7 +632,6 @@ resource "kubectl_manifest" "storageclass_efs" {
       provisioningMode: efs-ap
       fileSystemId: ${var.efs_file_system_id}
       directoryPerms: "700"
-      reuseAccessPoint: "true"
   YAML
 
   ignore_fields = ["metadata.uid", "metadata.resourceVersion"]


### PR DESCRIPTION
*Issue #, if available:* EFS Storage Class in EKS Standard reuseaccesspoint set to true

*Description of changes:* Remove reuseaccesspoint from Storage Class


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
