### PR TITLE
Experience for EKS users pre dynamo push should remain the same

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 # Platform type: eks | k8s
-PLATFORM=k8s
+PLATFORM=eks
 
 # EKS Settings (required when PLATFORM=eks)
 REGION=us-west-2

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ This command will:
 
 Note. Unlike the quick demo setup, the selected components and examples may not be deployed in the required order. Some components/examples might need to be refreshed by running the CLI install command again.
 
+## NVIDIA Dynamo Platform Setup
+
+This starter kit supports deploying [NVIDIA Dynamo](https://developer.nvidia.com/dynamo) for optimized LLM inference on Amazon EKS.
+
+### Quick Start
+
+1. Install components in order:
+
+```bash
+./cli nvidia-platform monitoring install      # Prometheus + Grafana
+./cli nvidia-platform gpu-operator install     # NVIDIA GPU Operator
+./cli nvidia-platform dynamo-platform install  # Dynamo CRDs, Operator, etcd, NATS
+./cli nvidia-platform dynamo-vllm install      # Deploy a model with vLLM
+```
+
+2. Optionally run benchmarks and auto-configuration:
+
+```bash
+./cli nvidia-platform benchmark install       # AIPerf concurrency sweep
+./cli nvidia-platform aiconfigurator install   # TP/PP recommendation + SLA deploy
+```
+
+For full details on platform prerequisites, deployment modes (aggregated vs disaggregated), KV cache routing, monitoring dashboards, benchmarking, and AIConfigurator, see the [NVIDIA Platform README](components/nvidia-platform/README.md).
+
 ## Components & Examples Management
 
 You can install or uninstall individual components/examples using the CLI:

--- a/config.json
+++ b/config.json
@@ -1,48 +1,4 @@
 {
-  "platform": {
-    "monitoring": {
-      "grafanaAdminPassword": "admin",
-      "retention": "7d",
-      "enablePersistentStorage": false,
-      "prometheusStorageSize": "50Gi",
-      "alertmanagerEnabled": false
-    },
-    "type": "eks",
-    "eks": {
-      "storageClass": "efs",
-      "gpuNodeSelectorKey": "nvidia.com/gpu.present",
-      "gpuNodeSelectorValue": "true",
-      "gpuOperator": {
-        "driverEnabled": false,
-        "toolkitEnabled": false,
-        "devicePluginEnabled": false,
-        "gfdEnabled": true,
-        "dcgmExporterEnabled": true,
-        "gdsEnabled": true,
-        "nfdEnabled": false,
-        "migManagerEnabled": false,
-        "useAMP": false,
-        "ampWorkspaceId": ""
-      },
-      "dynamoPlatform": {
-        "releaseVersion": "0.9.1",
-        "namespace": "dynamo-system",
-        "groveEnabled": true,
-        "kaiSchedulerEnabled": true
-      }
-    },
-    "k8s": {
-      "storageClass": "nfs",
-      "gpuNodeSelectorKey": "nvidia.com/gpu.present",
-      "gpuNodeSelectorValue": "true",
-      "dynamoPlatform": {
-        "releaseVersion": "0.9.0-post1",
-        "namespace": "dynamo-system",
-        "groveEnabled": true,
-        "kaiSchedulerEnabled": true
-      }
-    }
-  },
   "demo": {
     "components": [
       { "category": "llm-model", "component": "vllm" },
@@ -99,7 +55,15 @@
         { "name": "qwen3-8b-fp8", "deploy": false }
       ]
     },
-    "ollama": { "models": ["qwen3:32b", "qwen3:30b", "gemma3:27b", "deepseek-r1:8b", "nomic-embed-text:v1.5"] }
+    "ollama": {
+      "models": [
+        "qwen3:32b",
+        "qwen3:30b",
+        "gemma3:27b",
+        "deepseek-r1:8b",
+        "nomic-embed-text:v1.5"
+      ]
+    }
   },
   "embedding-model": {
     "tei": {
@@ -188,6 +152,50 @@
       "dockerhub_access_token": "",
       "github_username": "",
       "github_token": ""
+    }
+  },
+  "platform": {
+    "monitoring": {
+      "grafanaAdminPassword": "admin",
+      "retention": "7d",
+      "enablePersistentStorage": false,
+      "prometheusStorageSize": "50Gi",
+      "alertmanagerEnabled": false
+    },
+    "type": "eks",
+    "eks": {
+      "storageClass": "efs",
+      "gpuNodeSelectorKey": "nvidia.com/gpu.present",
+      "gpuNodeSelectorValue": "true",
+      "gpuOperator": {
+        "driverEnabled": false,
+        "toolkitEnabled": false,
+        "devicePluginEnabled": false,
+        "gfdEnabled": true,
+        "dcgmExporterEnabled": true,
+        "gdsEnabled": true,
+        "nfdEnabled": false,
+        "migManagerEnabled": false,
+        "useAMP": false,
+        "ampWorkspaceId": ""
+      },
+      "dynamoPlatform": {
+        "releaseVersion": "0.9.1",
+        "namespace": "dynamo-system",
+        "groveEnabled": true,
+        "kaiSchedulerEnabled": true
+      }
+    },
+    "k8s": {
+      "storageClass": "nfs",
+      "gpuNodeSelectorKey": "nvidia.com/gpu.present",
+      "gpuNodeSelectorValue": "true",
+      "dynamoPlatform": {
+        "releaseVersion": "0.9.0-post1",
+        "namespace": "dynamo-system",
+        "groveEnabled": true,
+        "kaiSchedulerEnabled": true
+      }
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Experience for EKS users pre dynamo push should remain the same. Thus, setting EKS to default. Adding Dynamo info to main readme and pushing platform setup to bottom of config.json to not confuse non-dynamo users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
