### PR TITLE
fix: add nltk==3.9.4 to requirements-lock.txt

### DIFF
--- a/components/guardrail/guardrails-ai/docker/requirements-lock.txt
+++ b/components/guardrail/guardrails-ai/docker/requirements-lock.txt
@@ -57,6 +57,7 @@ markdown-it-py==4.0.0
 markupsafe==3.0.3
 mdurl==0.1.2
 multidict==6.7.1
+nltk==3.9.4
 openai==2.31.0
 opentelemetry-api==1.41.0
 opentelemetry-exporter-otlp-proto-common==1.41.0


### PR DESCRIPTION
## Summary
- nltk was dropped during lock file regeneration in PR #114 but is required by the Dockerfile (`nltk.downloader punkt`)
- Adding it back at the latest patch version (3.9.4)

## Test plan
- [x] `pip install --dry-run` confirms zero dependency conflicts