### PR TITLE
docs: add MkDocs documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,48 @@
+name: Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install -r docs/requirements.txt
+
+      - name: Build documentation
+        run: mkdocs build --strict
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -20,9 +20,7 @@ Access Open WebUI at `openwebui.<DOMAIN>` and then:
 
 - **Agent pipe functions are automatically registered** when agents are installed (e.g., `./cli strands-agents calculator-agent install`). The `Strands Agents - Calculator Agent` function will appear in Open WebUI automatically.
 - Optionally, add [Time Token Tracker](https://openwebui.com/f/owndev/time_token_tracker) from the [Open WebUI Functions](https://docs.openwebui.com/features/plugin/functions/#%EF%B8%8F-how-to-use-functions) marketplace
-  ![Open WebUI Functions](../assets/openwebui_functions.png)
 - Change [Open WebUI RAG embedding model](https://docs.openwebui.com/features/rag#rag-embedding-support) to use the deployed Qwen3-Embedding model (check `LITELLM_API_KEY` on `.env.local` for API Key)
-  ![Open WebUI Functions](../assets/openwebui_embedding_model.png)
 
 ### Use Demo
 
@@ -32,8 +30,6 @@ Access Open WebUI at `openwebui.<DOMAIN>` and then:
 
    - Check [Tutorial: Configuring RAG with Open WebUI Documentation](https://docs.openwebui.com/tutorials/tips/rag-tutorial) on how to start using the document RAG feature
    - Select and explore `Strands Agents - Calculator Agent` (code available at `examples/strands-agents/calculator-agent`), this is a basic agent with memory so you can continue the calculation and/or reset the caculator
-
-   ![Open WebUI Functions](../assets/openwebui_embedding_calculator_agent.png)
 
 2. Access LiteLLM dashboard at `litellm.<DOMAIN>/ui` (check `LITELLM_UI_USERNAME` and `LITELLM_UI_PASSWORD` on `.env.local` for Username and Password):
    - Check [LiteLLM Proxy Server (LLM Gateway)](https://docs.litellm.ai/docs/simple_proxy) to explore some of the features

--- a/docs/assets/images/logo.svg
+++ b/docs/assets/images/logo.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect width="64" height="64" rx="12" fill="#7C3AED"/>
+  <text x="32" y="24" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="white" text-anchor="middle">GenAI</text>
+  <text x="32" y="38" font-family="Arial, sans-serif" font-size="10" fill="white" text-anchor="middle">on</text>
+  <text x="32" y="52" font-family="Arial, sans-serif" font-size="12" font-weight="bold" fill="#FCD34D" text-anchor="middle">EKS</text>
+</svg>

--- a/docs/components/ai-agent/openclaw.md
+++ b/docs/components/ai-agent/openclaw.md
@@ -1,0 +1,199 @@
+# OpenClaw
+
+Lightweight bridge server that orchestrates AI coding agents on Kubernetes. Provides a stateless, Git-native workflow where agents clone repositories, make changes, commit, and push within ephemeral containers.
+
+| | |
+|---|---|
+| **Category** | ai-agent |
+| **Official Docs** | [OpenClaw Repository](https://github.com/openclaw/openclaw) |
+| **CLI Install** | `./cli ai-agent openclaw install` |
+| **CLI Uninstall** | `./cli ai-agent openclaw uninstall` |
+| **Namespace** | `openclaw` |
+
+## Overview
+
+OpenClaw deploys a central bridge server that:
+- **Task Routing**: Receives task requests and routes to appropriate agent containers
+- **Real-Time Streaming**: Streams agent responses back to clients
+- **LiteLLM Integration**: Routes all LLM calls through LiteLLM gateway
+- **Langfuse Observability**: Sends traces for monitoring and debugging
+- **Open WebUI Integration**: Works as a backend for Open WebUI pipe functions
+- **Stateless Design**: Git is the durable store; containers are ephemeral
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                         Open WebUI                               │
+│                    (GUI, Pipe Functions)                         │
+└────────────────────────────┬────────────────────────────────────┘
+                             │
+                             ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                    OpenClaw Bridge Server                        │
+│                  (Task Router, Orchestrator)                     │
+│                  http://openclaw.openclaw:8080                   │
+└─────────┬───────────────────────────────────────────┬───────────┘
+          │                                           │
+          ▼                                           ▼
+┌──────────────────────┐                  ┌──────────────────────┐
+│  Doc Writer Agent    │                  │   DevOps Agent       │
+│  (Example)           │                  │   (Example)          │
+└──────────────────────┘                  └──────────────────────┘
+          │                                           │
+          └───────────────────┬───────────────────────┘
+                              ▼
+                    ┌──────────────────────┐
+                    │   LiteLLM Gateway    │
+                    └──────────────────────┘
+```
+
+## Installation
+
+### Prerequisites
+
+- [LiteLLM](../ai-gateway/litellm.md) installed (`./cli ai-gateway litellm install`)
+- `LITELLM_API_KEY` set in `.env`
+
+### Install
+
+```bash
+./cli ai-agent openclaw install
+```
+
+The installer:
+1. Deploys the bridge server using a pre-built public ECR image
+2. Creates Kubernetes Service at `http://openclaw.openclaw:8080`
+3. Auto-detects and configures Langfuse integration if available
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n openclaw
+
+# Check service
+kubectl get svc -n openclaw
+
+# Check logs
+kubectl logs -n openclaw -l app=openclaw
+
+# Test health endpoint
+kubectl port-forward -n openclaw svc/openclaw 8080:8080
+curl http://localhost:8080/health
+```
+
+Expected output:
+
+```json
+{"status":"ok"}
+```
+
+## Configuration
+
+### config.json
+
+```json
+{
+  "ai-agent": {
+    "openclaw": {
+      "env": {
+        "LITELLM_MODEL_NAME": "bedrock/claude-4.5-sonnet",
+        "OPENCLAW_GATEWAY_TOKEN": "openclaw-gateway-token"
+      }
+    }
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `OPENCLAW_GATEWAY_TOKEN` | Authentication token | `openclaw-gateway-token` |
+| `LITELLM_BASE_URL` | LiteLLM API endpoint | `http://litellm.litellm:4000` |
+| `LITELLM_API_KEY` | LiteLLM API key | From `.env` |
+| `LITELLM_MODEL_NAME` | Default model | `bedrock/claude-4.5-sonnet` |
+| `LANGFUSE_HOST` | Langfuse endpoint (optional) | `http://langfuse-web.langfuse:3000` |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public key (optional) | From `.env` |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret key (optional) | From `.env` |
+
+### Switching Models
+
+Update `LITELLM_MODEL_NAME` in `config.json` and reinstall:
+
+```bash
+./cli ai-agent openclaw uninstall
+./cli ai-agent openclaw install
+```
+
+## Integration
+
+### Langfuse
+
+If [Langfuse](../observability/langfuse.md) is installed, OpenClaw automatically sends traces for:
+- Task submissions and agent responses
+- LLM API calls with token usage
+- Error events and latency metrics
+
+### Open WebUI
+
+[Open WebUI](../gui-app/openwebui.md) connects to OpenClaw via pipe functions to provide agent capabilities in the chat interface.
+
+## Examples
+
+See the following examples for complete agent implementations:
+
+- [Document Writer Agent](../../examples/openclaw/doc-writer.md): Clones Git repos, writes documentation, commits and pushes
+- [DevOps Agent](../../examples/openclaw/devops-agent.md): Interactive cluster management with kubectl, helm, and AWS CLI
+
+## Cost Optimization
+
+- **Stateless containers**: No persistent storage (Git is the durable store)
+- **Spot instances**: Karpenter provisions Spot ARM64 nodes (up to 90% savings)
+- **Ephemeral execution**: Jobs terminate after completion
+- **Estimated cost**: ~$0 at rest, ~$0.02-0.05 per task (excluding LLM API costs)
+
+## Security
+
+- **Authentication**: Optional Bearer token auth via `OPENCLAW_GATEWAY_TOKEN`
+- **Network**: Bridge server only accessible within cluster (ClusterIP service)
+- **RBAC**: ServiceAccount with minimal permissions
+
+## Troubleshooting
+
+### Bridge server not starting
+
+```bash
+# Check pod events
+kubectl describe pod -n openclaw -l app=openclaw
+
+# Check logs
+kubectl logs -n openclaw -l app=openclaw
+```
+
+### Cannot connect to LiteLLM
+
+```bash
+# Check LiteLLM is running
+kubectl get pods -n litellm
+
+# Test from OpenClaw pod
+kubectl exec -it -n openclaw <openclaw-pod> -- \
+  curl http://litellm.litellm:4000/health
+```
+
+### Agent tasks failing
+
+```bash
+# Check agent logs
+kubectl logs -n openclaw -l app=openclaw --tail=100
+
+# Check Langfuse traces for error details
+```
+
+## Learn More
+
+- [OpenClaw Repository](https://github.com/openclaw/openclaw)
+- [LiteLLM Documentation](https://docs.litellm.ai)
+- [Langfuse Documentation](https://langfuse.com/docs)

--- a/docs/components/ai-gateway/kong.md
+++ b/docs/components/ai-gateway/kong.md
@@ -1,0 +1,231 @@
+# Kong AI Gateway
+
+Enterprise-grade API gateway with advanced rate limiting, authentication, and AI-specific plugins for LLM applications.
+
+| | |
+|---|---|
+| **Category** | ai-gateway |
+| **Official Docs** | [Kong Gateway Documentation](https://docs.konghq.com/) |
+| **CLI Install** | `./cli ai-gateway kong install` |
+| **CLI Uninstall** | `./cli ai-gateway kong uninstall` |
+| **Namespace** | `kong` |
+
+## Overview
+
+Kong Gateway provides enterprise features for LLM applications:
+- **Authentication**: API key, OAuth2, JWT
+- **Rate Limiting**: Advanced throttling policies
+- **Request/Response Transformation**: Modify payloads on the fly
+- **AI Plugins**: AI prompt guard, AI request transformer, AI rate limiting
+- **Observability**: Datadog, Prometheus, StatsD integration
+- **High Availability**: Multi-instance deployments with PostgreSQL backend
+
+## Installation
+
+```bash
+./cli ai-gateway kong install
+```
+
+The installer deploys:
+1. PostgreSQL database for Kong state
+2. Kong Gateway with DB mode
+3. Kong Ingress Controller (optional)
+4. Admin API and Proxy services
+
+## Verification
+
+```bash
+# Check Kong pods
+kubectl get pods -n kong
+
+# Check services
+kubectl get svc -n kong
+
+# Port-forward Admin API
+kubectl port-forward svc/kong-admin 8001:8001 -n kong --address 0.0.0.0 &
+
+# Check Kong status
+curl http://localhost:8001/status
+
+# List services
+curl http://localhost:8001/services
+```
+
+## Configuration
+
+### Exposing Backend Services
+
+Create Kong Service and Route for LiteLLM:
+
+```bash
+# Create Service
+curl -X POST http://localhost:8001/services \
+  --data name=litellm \
+  --data url=http://litellm.litellm:4000
+
+# Create Route
+curl -X POST http://localhost:8001/services/litellm/routes \
+  --data paths[]=/litellm \
+  --data strip_path=true
+```
+
+### Rate Limiting
+
+Add rate limiting plugin:
+
+```bash
+curl -X POST http://localhost:8001/services/litellm/plugins \
+  --data name=rate-limiting \
+  --data config.minute=100 \
+  --data config.policy=local
+```
+
+### Authentication
+
+Enable API key authentication:
+
+```bash
+# Add key-auth plugin
+curl -X POST http://localhost:8001/services/litellm/plugins \
+  --data name=key-auth
+
+# Create consumer
+curl -X POST http://localhost:8001/consumers \
+  --data username=myapp
+
+# Create API key
+curl -X POST http://localhost:8001/consumers/myapp/key-auth \
+  --data key=my-secret-key
+```
+
+Test with API key:
+
+```bash
+curl http://localhost:8000/litellm/v1/models \
+  -H "apikey: my-secret-key"
+```
+
+### AI Rate Limiting
+
+Kong's AI Rate Limiting plugin provides token-based throttling:
+
+```bash
+curl -X POST http://localhost:8001/services/litellm/plugins \
+  --data name=ai-rate-limiting-advanced \
+  --data config.limit_by=consumer \
+  --data config.window_size=60 \
+  --data config.window_type=sliding \
+  --data config.max_tokens=10000
+```
+
+## Usage
+
+### Access via Kong Proxy
+
+```bash
+# Port-forward Kong proxy
+kubectl port-forward svc/kong-proxy 8000:8000 -n kong --address 0.0.0.0 &
+
+# Make request through Kong
+curl http://localhost:8000/litellm/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "apikey: my-secret-key" \
+  -d '{
+    "model": "vllm/qwen3-30b-instruct-fp8",
+    "messages": [{"role": "user", "content": "Hello!"}]
+  }'
+```
+
+### Declarative Configuration
+
+Create Kong resources via YAML:
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+  name: rate-limiting
+  namespace: kong
+config:
+  minute: 100
+  policy: local
+plugin: rate-limiting
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: litellm-proxy
+  namespace: kong
+  annotations:
+    konghq.com/plugins: rate-limiting
+spec:
+  selector:
+    app: litellm
+  ports:
+  - port: 4000
+    targetPort: 4000
+```
+
+## Observability
+
+### Prometheus Metrics
+
+Enable Prometheus plugin:
+
+```bash
+curl -X POST http://localhost:8001/plugins \
+  --data name=prometheus
+```
+
+Metrics available at `http://kong-admin.kong:8001/metrics`.
+
+### Logging
+
+Enable file-log plugin to send logs to external systems:
+
+```bash
+curl -X POST http://localhost:8001/plugins \
+  --data name=file-log \
+  --data config.path=/tmp/kong.log
+```
+
+## Troubleshooting
+
+### Kong pods not starting
+
+```bash
+# Check PostgreSQL connection
+kubectl logs -n kong -l app=kong | grep postgres
+
+# Check database migrations
+kubectl logs -n kong -l job-name=kong-migrations
+```
+
+### Admin API not accessible
+
+```bash
+# Check Admin API service
+kubectl get svc -n kong kong-admin
+
+# Check port-forward
+kubectl port-forward svc/kong-admin 8001:8001 -n kong --address 0.0.0.0 &
+curl http://localhost:8001/status
+```
+
+### Rate limiting not working
+
+```bash
+# Check plugin is enabled
+curl http://localhost:8001/services/litellm/plugins | jq '.data[] | select(.name=="rate-limiting")'
+
+# Check rate limit headers in response
+curl -i http://localhost:8000/litellm/v1/models
+# Look for: X-RateLimit-Limit-Minute, X-RateLimit-Remaining-Minute
+```
+
+## Learn More
+
+- [Kong Gateway Documentation](https://docs.konghq.com/)
+- [Kong AI Plugins](https://docs.konghq.com/hub/?category=ai)
+- [Kong Ingress Controller](https://docs.konghq.com/kubernetes-ingress-controller/)
+- [Rate Limiting Plugin](https://docs.konghq.com/hub/kong-inc/rate-limiting/)

--- a/docs/components/ai-gateway/litellm.md
+++ b/docs/components/ai-gateway/litellm.md
@@ -1,0 +1,273 @@
+# LiteLLM
+
+Universal LLM gateway that provides a unified OpenAI-compatible API for 100+ LLM providers. Route requests across vLLM, SGLang, TGI, AWS Bedrock, and more with built-in load balancing, rate limiting, and cost tracking.
+
+| | |
+|---|---|
+| **Category** | ai-gateway |
+| **Official Docs** | [LiteLLM Documentation](https://docs.litellm.ai) |
+| **CLI Install** | `./cli ai-gateway litellm install` |
+| **CLI Uninstall** | `./cli ai-gateway litellm uninstall` |
+| **Namespace** | `litellm` |
+
+## Overview
+
+LiteLLM acts as a proxy layer between your applications and LLM providers, offering:
+- **Unified API**: Single OpenAI-compatible interface for all providers
+- **Model Routing**: Automatic failover and load balancing across models
+- **Cost Tracking**: Real-time spend monitoring and budget limits
+- **Rate Limiting**: Per-user, per-key, or per-model throttling
+- **Guardrails Integration**: Optional Guardrails AI and AWS Bedrock Guardrails
+- **Observability**: Langfuse tracing and analytics
+
+## Installation
+
+```bash
+./cli ai-gateway litellm install
+```
+
+The installer automatically:
+1. Detects deployed vLLM, SGLang, TGI models
+2. Configures AWS Bedrock models from `config.json`
+3. Generates `config.yaml` with model routing
+4. Deploys LiteLLM proxy to `litellm` namespace
+5. Configures Guardrails AI if enabled
+6. Sets up Langfuse integration if installed
+
+## Verification
+
+```bash
+# Check LiteLLM pods
+kubectl get pods -n litellm
+
+# Check service
+kubectl get svc -n litellm
+
+# Port-forward for testing
+kubectl port-forward svc/litellm 4000:4000 -n litellm --address 0.0.0.0 &
+
+# List available models
+curl http://localhost:4000/v1/models
+
+# Test chat completion
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "vllm/qwen3-30b-instruct-fp8",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
+```
+
+## Configuration
+
+### Model Routing
+
+LiteLLM automatically discovers and configures models from:
+- **vLLM**: Detects Dynamo vLLM deployments in `dynamo-system` namespace
+- **SGLang/TGI/Ollama**: Detects deployments in respective namespaces
+- **AWS Bedrock**: Reads from `config.json` → `bedrock.llm.models`
+
+Example generated `config.yaml`:
+
+```yaml
+model_list:
+  # vLLM models (auto-detected)
+  - model_name: qwen3-30b-instruct-fp8
+    litellm_params:
+      model: openai/qwen3-30b-instruct-fp8
+      api_base: http://qwen3-30b-fp8-frontend.dynamo-system:8000/v1
+
+  # AWS Bedrock models (from config.json)
+  - model_name: claude-4.5-sonnet
+    litellm_params:
+      model: bedrock/global.anthropic.claude-sonnet-4-5-20250929-v1:0
+      aws_region_name: us-east-1
+
+  # SGLang models (auto-detected)
+  - model_name: qwen3-32b-fp8-sglang
+    litellm_params:
+      model: openai/qwen3-32b-fp8
+      api_base: http://qwen3-32b-fp8.sglang:8000/v1
+```
+
+### Guardrails Integration
+
+Enable Guardrails AI in `config.json`:
+
+```json
+{
+  "litellm": {
+    "enableBedrockGuardrail": false,
+    "enableGuardrailsAI": true
+  }
+}
+```
+
+Then reinstall:
+```bash
+./cli ai-gateway litellm uninstall
+./cli ai-gateway litellm install
+```
+
+LiteLLM will route requests through Guardrails AI for content validation before sending to the LLM.
+
+### Environment Variables
+
+Configure in `.env`:
+
+```bash
+# AWS Credentials (for Bedrock)
+AWS_ACCESS_KEY_ID=AKIA...
+AWS_SECRET_ACCESS_KEY=...
+AWS_DEFAULT_REGION=us-east-1
+
+# LiteLLM Master Key
+LITELLM_MASTER_KEY=sk-1234567890abcdef
+
+# Langfuse (optional)
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+```
+
+## Usage
+
+### From Applications
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    api_key="sk-1234",  # LiteLLM master key
+    base_url="http://litellm.litellm:4000"
+)
+
+response = client.chat.completions.create(
+    model="vllm/qwen3-30b-instruct-fp8",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+### From Open WebUI
+
+Configure Open WebUI to use LiteLLM as the backend:
+
+```bash
+# Set in Open WebUI environment
+OPENAI_API_BASE_URL=http://litellm.litellm:4000/v1
+OPENAI_API_KEY=sk-1234
+```
+
+### From curl
+
+```bash
+curl http://litellm.litellm:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer sk-1234" \
+  -d '{
+    "model": "vllm/qwen3-30b-instruct-fp8",
+    "messages": [{"role": "user", "content": "Explain quantum computing"}],
+    "max_tokens": 200,
+    "temperature": 0.7
+  }'
+```
+
+## Load Balancing
+
+Configure multiple endpoints for the same model to enable load balancing:
+
+```yaml
+model_list:
+  - model_name: qwen3-30b-fp8
+    litellm_params:
+      model: openai/qwen3-30b-fp8
+      api_base: http://qwen3-replica-1.dynamo-system:8000/v1
+  
+  - model_name: qwen3-30b-fp8
+    litellm_params:
+      model: openai/qwen3-30b-fp8
+      api_base: http://qwen3-replica-2.dynamo-system:8000/v1
+```
+
+LiteLLM will automatically round-robin requests across replicas.
+
+## Rate Limiting
+
+Add to `config.yaml`:
+
+```yaml
+litellm_settings:
+  max_parallel_requests: 100
+  max_requests_per_minute: 1000
+  
+  # Per-key limits
+  api_key_limits:
+    sk-user1: 100  # requests per minute
+    sk-user2: 500
+```
+
+## Cost Tracking
+
+LiteLLM tracks token usage and estimated costs. View in logs:
+
+```bash
+kubectl logs -n litellm -l app=litellm | grep "cost"
+```
+
+For detailed analytics, enable [Langfuse integration](../observability/langfuse.md).
+
+## Observability
+
+If [Langfuse](../observability/langfuse.md) is installed, LiteLLM automatically sends traces:
+
+```bash
+# Check Langfuse integration
+kubectl logs -n litellm -l app=litellm | grep langfuse
+```
+
+View traces in Langfuse UI:
+- Request/response pairs
+- Token usage
+- Latency breakdown
+- Model routing decisions
+
+## Troubleshooting
+
+### Models not appearing
+
+```bash
+# Check LiteLLM config
+kubectl get cm -n litellm litellm-config -o yaml
+
+# Check logs for discovery errors
+kubectl logs -n litellm -l app=litellm | grep ERROR
+```
+
+### Connection refused to backend
+
+```bash
+# Check backend service exists
+kubectl get svc -n dynamo-system | grep frontend
+kubectl get svc -n sglang
+kubectl get svc -n tgi
+
+# Test connectivity from LiteLLM pod
+kubectl exec -it -n litellm <litellm-pod> -- curl http://<backend-svc>.<namespace>:8000/v1/models
+```
+
+### AWS Bedrock authentication errors
+
+```bash
+# Check AWS credentials
+kubectl get secret -n litellm litellm-secrets -o yaml
+
+# Test AWS credentials
+kubectl exec -it -n litellm <litellm-pod> -- aws bedrock list-foundation-models --region us-east-1
+```
+
+## Learn More
+
+- [LiteLLM Documentation](https://docs.litellm.ai)
+- [LiteLLM Proxy Configuration](https://docs.litellm.ai/docs/proxy/configs)
+- [Supported LLM Providers](https://docs.litellm.ai/docs/providers)

--- a/docs/components/embedding-model/tei.md
+++ b/docs/components/embedding-model/tei.md
@@ -1,0 +1,172 @@
+# Text Embedding Inference (TEI)
+
+Hugging Face's high-performance inference server for text embedding models. Optimized for production workloads with support for batching, tokenization, and multiple model architectures.
+
+| | |
+|---|---|
+| **Category** | embedding-model |
+| **Official Docs** | [TEI Documentation](https://huggingface.co/docs/text-embeddings-inference) |
+| **CLI Install** | `./cli embedding-model tei install` |
+| **CLI Uninstall** | `./cli embedding-model tei uninstall` |
+| **Namespace** | `tei` |
+
+## Overview
+
+TEI is a purpose-built server for text embeddings with:
+- **High Throughput**: Optimized for batch embedding generation
+- **Multiple Architectures**: BERT, XLM-RoBERTa, GTE, and more
+- **Token Batching**: Automatic batching for optimal throughput
+- **CPU & GPU**: Run on CPU for small models or GPU for large models
+- **OpenAI-Compatible API**: Drop-in replacement for OpenAI embeddings API
+- **Sequence Classification**: Also supports reranking models
+
+## Installation
+
+```bash
+./cli embedding-model tei install
+```
+
+The installer:
+1. Creates the `tei` namespace
+2. Sets up PVC for model storage
+3. Configures HuggingFace token secret
+4. Deploys selected embedding models from `config.json`
+
+### Prerequisites
+
+- `HF_TOKEN` environment variable set in `.env`
+
+### Model Selection
+
+Pre-configured models in `config.json`:
+
+```json
+{
+  "embedding-model": {
+    "tei": {
+      "models": [
+        { "name": "qwen3-embedding-06b-bf16-cpu", "deploy": true },
+        { "name": "qwen3-embedding-06b-bf16", "deploy": false },
+        { "name": "qwen3-embedding-4b-bf16", "deploy": false },
+        { "name": "qwen3-embedding-8b-bf16", "deploy": false }
+      ]
+    }
+  }
+}
+```
+
+The `-cpu` suffix models run on CPU nodes (no GPU required), while others require GPU nodes.
+
+## Verification
+
+```bash
+# Check TEI pods
+kubectl get pods -n tei
+
+# Check service
+kubectl get svc -n tei
+
+# Port-forward for testing
+kubectl port-forward svc/tei 8080:8080 -n tei --address 0.0.0.0 &
+
+# Test embedding generation
+curl http://localhost:8080/embed \
+  -H "Content-Type: application/json" \
+  -d '{
+    "inputs": "What is deep learning?"
+  }'
+
+# Test OpenAI-compatible endpoint
+curl http://localhost:8080/v1/embeddings \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-embedding-06b-bf16-cpu",
+    "input": "What is deep learning?"
+  }'
+```
+
+## Configuration
+
+### Model Templates
+
+Each model has a template at `components/embedding-model/tei/model-<name>.template.yaml` defining:
+- Model ID (HuggingFace repository)
+- Resource requests (CPU/GPU, memory)
+- TEI server arguments
+- Node selectors
+
+### Environment Variables
+
+Configure in `.env`:
+
+```bash
+# Required for gated models
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxx
+```
+
+## Model Management
+
+```bash
+# Configure models
+./cli embedding-model tei configure-models
+
+# Add models
+./cli embedding-model tei add-models
+
+# Update models
+./cli embedding-model tei update-models
+
+# Remove all models
+./cli embedding-model tei remove-all-models
+```
+
+## Usage
+
+### From Python
+
+```python
+import requests
+
+response = requests.post(
+    "http://tei.tei:8080/v1/embeddings",
+    json={
+        "model": "qwen3-embedding-06b-bf16-cpu",
+        "input": ["What is deep learning?", "How does attention work?"]
+    }
+)
+embeddings = response.json()["data"]
+```
+
+### With Vector Databases
+
+TEI embeddings can be stored in [Qdrant](../vector-database/qdrant.md), [Chroma](../vector-database/chroma.md), or [Milvus](../vector-database/milvus.md) for similarity search.
+
+## Troubleshooting
+
+### Model download fails
+
+```bash
+# Check PVC exists and is bound
+kubectl get pvc -n tei
+
+# Check HuggingFace token
+kubectl get secret -n tei huggingface-secret
+
+# Check pod logs
+kubectl logs -n tei -l app=tei -f
+```
+
+### High latency
+
+```bash
+# Check if model is on CPU vs GPU
+kubectl describe pod -n tei -l app=tei | grep -A5 "Resources"
+
+# Consider GPU model variant for lower latency
+```
+
+## Learn More
+
+- [TEI Documentation](https://huggingface.co/docs/text-embeddings-inference)
+- [TEI GitHub Repository](https://github.com/huggingface/text-embeddings-inference)
+- [Supported Models](https://huggingface.co/docs/text-embeddings-inference/supported_models)

--- a/docs/components/guardrail/guardrails-ai.md
+++ b/docs/components/guardrail/guardrails-ai.md
@@ -1,0 +1,141 @@
+# Guardrails AI
+
+Input/output validation framework for LLMs. Detects and filters PII, toxic content, and other policy violations in real-time, integrating with LiteLLM as a guardrail middleware.
+
+| | |
+|---|---|
+| **Category** | guardrail |
+| **Official Docs** | [Guardrails AI Documentation](https://www.guardrailsai.com/docs) |
+| **CLI Install** | `./cli guardrail guardrails-ai install` |
+| **CLI Uninstall** | `./cli guardrail guardrails-ai uninstall` |
+| **Namespace** | `guardrails-ai` |
+
+## Overview
+
+Guardrails AI provides a validation layer for LLM inputs and outputs:
+- **PII Detection**: Detect and mask emails, phone numbers, IP addresses, SSNs
+- **Content Validation**: Check outputs against custom validation rules
+- **LiteLLM Integration**: Acts as middleware in the LLM request pipeline
+- **Guard Hub**: Access community-maintained validators
+- **Streaming Support**: Validate streaming LLM responses in real-time
+
+## Installation
+
+### Prerequisites
+
+- `GUARDRAILS_AI_API_KEY` environment variable set in `.env`
+
+```bash
+./cli guardrail guardrails-ai install
+```
+
+The installer:
+1. Uses a pre-built public ECR image
+2. Renders the deployment template with configuration
+3. Deploys the Guardrails AI server to the cluster
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n guardrails-ai
+
+# Check service
+kubectl get svc -n guardrails-ai
+
+# Port-forward for testing
+kubectl port-forward svc/guardrails-ai 8000:8000 -n guardrails-ai --address 0.0.0.0 &
+
+# Test PII detection
+curl -X POST 'http://localhost:8000/guards/detect-pii/validate' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "llmOutput": "My email address is john.doe@example.com, my IP address is 192.168.1.1, and my phone number is 123-456-7890"
+  }'
+```
+
+## Configuration
+
+### Environment Variables
+
+Configure in `.env`:
+
+```bash
+# Required
+GUARDRAILS_AI_API_KEY=your-guardrails-api-key
+```
+
+### Enabling in LiteLLM
+
+Enable Guardrails AI as a middleware in `config.json`:
+
+```json
+{
+  "litellm": {
+    "enableGuardrailsAI": true
+  }
+}
+```
+
+Then reinstall LiteLLM:
+
+```bash
+./cli ai-gateway litellm uninstall
+./cli ai-gateway litellm install
+```
+
+LiteLLM will route requests through Guardrails AI for content validation before sending to the LLM.
+
+## Testing
+
+### Via Open WebUI
+
+Send messages containing PII to test detection:
+
+```
+Validate this email address - genai-on-eks@example.com
+Validate this IP address - 50.0.10.1
+Validate this phone number - 829-456-7890
+```
+
+### Via curl
+
+```bash
+curl -X POST 'http://localhost:8000/guards/detect-pii/validate' \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "llmOutput": "My email address is john.doe@example.com, my IP address and 192.168.1.1, and my phone number is 123-456-7890"
+  }'
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+# Check pod events
+kubectl describe pod -n guardrails-ai -l app=guardrails-ai
+
+# Check logs
+kubectl logs -n guardrails-ai -l app=guardrails-ai
+
+# Verify API key
+kubectl get secret -n guardrails-ai -o yaml
+```
+
+### Guardrails not triggering in LiteLLM
+
+```bash
+# Verify enableGuardrailsAI is true in config
+cat config.json | grep enableGuardrailsAI
+
+# Check LiteLLM logs for guardrail integration
+kubectl logs -n litellm -l app=litellm | grep guardrail
+```
+
+## Learn More
+
+- [Guardrails AI Documentation](https://www.guardrailsai.com/docs)
+- [Guardrails Hub](https://hub.guardrailsai.com)
+- [PII Detection Guard](https://github.com/guardrails-ai/detect_pii)
+- [Guardrails Lite Server](https://github.com/guardrails-ai/guardrails-lite-server)

--- a/docs/components/gui-app/openwebui.md
+++ b/docs/components/gui-app/openwebui.md
@@ -1,0 +1,164 @@
+# Open WebUI
+
+Feature-rich, self-hosted web interface for interacting with LLMs. Provides a ChatGPT-like experience with support for multiple models, RAG, tools, and collaborative features.
+
+| | |
+|---|---|
+| **Category** | gui-app |
+| **Official Docs** | [Open WebUI Documentation](https://docs.openwebui.com) |
+| **CLI Install** | `./cli gui-app openwebui install` |
+| **CLI Uninstall** | `./cli gui-app openwebui uninstall` |
+| **Namespace** | `openwebui` |
+
+## Overview
+
+Open WebUI serves as the primary user interface for the starter kit:
+- **Chat Interface**: Conversational UI with streaming, markdown, and code highlighting
+- **Multi-Model**: Switch between models via LiteLLM integration
+- **RAG**: Built-in document upload and retrieval-augmented generation
+- **Tools & Functions**: Extensible pipe functions for custom integrations
+- **User Management**: Multi-user support with roles and permissions
+- **Conversation History**: Persistent chat history and conversation export
+- **Model Presets**: Save and share model configurations
+
+## Installation
+
+### Prerequisites
+
+Configure in `.env`:
+
+```bash
+LITELLM_API_KEY=sk-1234567890abcdef
+OPENWEBUI_ADMIN_EMAIL=admin@example.com
+OPENWEBUI_ADMIN_PASSWORD=your-password
+```
+
+### Install
+
+```bash
+./cli gui-app openwebui install
+```
+
+The installer:
+1. Adds the Open WebUI Helm chart repository
+2. Renders Helm values with LiteLLM connection and admin credentials
+3. Deploys Open WebUI via Helm chart (version 12.8.1)
+4. Creates the `openwebui` namespace
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n openwebui
+
+# Check service
+kubectl get svc -n openwebui
+
+# Check ingress
+kubectl get ingress -n openwebui
+
+# Port-forward for local access
+kubectl port-forward svc/openwebui 3000:8080 -n openwebui --address 0.0.0.0 &
+
+# Access Open WebUI
+open http://localhost:3000
+```
+
+Log in with `OPENWEBUI_ADMIN_EMAIL` and `OPENWEBUI_ADMIN_PASSWORD`.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `LITELLM_API_KEY` | LiteLLM API key for model access |
+| `OPENWEBUI_ADMIN_EMAIL` | Admin account email |
+| `OPENWEBUI_ADMIN_PASSWORD` | Admin account password |
+| `DOMAIN` | Domain for ingress (e.g., `openwebui.example.com`) |
+
+### LiteLLM Backend
+
+Open WebUI connects to [LiteLLM](../ai-gateway/litellm.md) as its backend:
+
+```bash
+OPENAI_API_BASE_URL=http://litellm.litellm:4000/v1
+OPENAI_API_KEY=sk-1234
+```
+
+All models configured in LiteLLM (vLLM, SGLang, TGI, Ollama, Bedrock) appear in the Open WebUI model selector.
+
+### OpenClaw Integration
+
+Open WebUI integrates with [OpenClaw](../ai-agent/openclaw.md) via pipe functions to enable AI agent capabilities directly from the chat interface.
+
+## Features
+
+### Document Upload (RAG)
+
+1. Click the attachment icon in the chat input
+2. Upload a document (PDF, TXT, DOCX, etc.)
+3. Ask questions about the uploaded document
+4. Open WebUI uses embedded models to retrieve relevant content
+
+### Custom Pipe Functions
+
+Extend Open WebUI with custom Python functions:
+
+```python
+# Example: OpenClaw integration pipe
+class Pipe:
+    def __init__(self):
+        self.valves = Valves(
+            OPENCLAW_URL="http://openclaw.openclaw:8080",
+            OPENCLAW_TOKEN="openclaw-gateway-token"
+        )
+
+    def pipe(self, body):
+        # Route request to OpenClaw agent
+        pass
+```
+
+## Troubleshooting
+
+### Cannot connect to models
+
+```bash
+# Check LiteLLM is running
+kubectl get pods -n litellm
+
+# Check Open WebUI environment
+kubectl exec -it -n openwebui <openwebui-pod> -- env | grep OPENAI
+
+# Check LiteLLM connectivity from Open WebUI
+kubectl exec -it -n openwebui <openwebui-pod> -- \
+  curl http://litellm.litellm:4000/v1/models
+```
+
+### Login fails
+
+```bash
+# Check admin credentials in values
+kubectl get secret -n openwebui -o yaml
+
+# Check Open WebUI logs
+kubectl logs -n openwebui -l app=openwebui
+```
+
+### Slow responses
+
+```bash
+# Check LLM backend health
+kubectl get pods -n vllm
+kubectl get pods -n sglang
+
+# Check Open WebUI pod resources
+kubectl top pod -n openwebui
+```
+
+## Learn More
+
+- [Open WebUI Documentation](https://docs.openwebui.com)
+- [Open WebUI GitHub](https://github.com/open-webui/open-webui)
+- [Open WebUI Helm Charts](https://github.com/open-webui/helm-charts)
+- [Pipe Functions Guide](https://docs.openwebui.com/tutorials/plugin/functions)

--- a/docs/components/index.md
+++ b/docs/components/index.md
@@ -1,0 +1,142 @@
+# Components Overview
+
+The GenAI on EKS Starter Kit provides a curated collection of production-ready components for building and deploying GenAI applications on Kubernetes. All components are installed via the CLI: `./cli <category> <component> install`.
+
+## Component Categories
+
+| Category | Description | Components |
+|----------|-------------|------------|
+| **NVIDIA Platform** | NVIDIA Dynamo LLM serving platform with GPU acceleration, monitoring, and benchmarking | GPU Operator, Monitoring, Dynamo Platform, Dynamo vLLM, AIPerf Benchmark, AIConfigurator |
+| **AI Gateway** | API gateways and proxies for LLM routing, load balancing, and rate limiting | LiteLLM, Kong |
+| **LLM Model** | Large Language Model serving engines | vLLM, SGLang, TGI, Ollama |
+| **Embedding Model** | Text embedding generation services | TEI (Text Embeddings Inference) |
+| **Guardrail** | Content safety and policy enforcement | Guardrails AI |
+| **Observability** | Monitoring, tracing, and analytics for GenAI applications | Langfuse, MLflow, Phoenix |
+| **GUI Application** | User interfaces for interacting with LLMs | Open WebUI |
+| **Vector Database** | High-performance vector storage for RAG applications | Qdrant, Chroma, Milvus |
+| **Workflow Automation** | Visual workflow builders and automation platforms | n8n |
+| **AI Agent** | Agent orchestration and task routing systems | OpenClaw |
+
+## Quick Start
+
+```bash
+# Install a component
+./cli <category> <component> install
+
+# Example: Install vLLM
+./cli llm-model vllm install
+
+# Uninstall a component
+./cli <category> <component> uninstall
+```
+
+## Component Index
+
+### NVIDIA Platform
+- [Overview](nvidia-platform/index.md) - NVIDIA Dynamo Platform architecture and installation guide
+- [GPU Operator](nvidia-platform/gpu-operator.md) - NVIDIA GPU resource management
+- [Monitoring](nvidia-platform/monitoring.md) - Prometheus + Grafana with Dynamo dashboards
+- [Dynamo Platform](nvidia-platform/dynamo-platform.md) - CRDs, Operator, etcd, NATS
+- [Dynamo vLLM](nvidia-platform/dynamo-vllm.md) - Aggregated/disaggregated vLLM serving
+- [AIPerf Benchmark](nvidia-platform/benchmark.md) - Comprehensive LLM benchmarking suite
+- [AIConfigurator](nvidia-platform/aiconfigurator.md) - Auto TP/PP recommendation and SLA-driven deployment
+
+### AI Gateway
+- [LiteLLM](ai-gateway/litellm.md) - Universal LLM gateway with unified API
+- [Kong](ai-gateway/kong.md) - API gateway with rate limiting and authentication
+
+### LLM Model
+- [vLLM](llm-model/vllm.md) - High-throughput LLM serving with PagedAttention
+- [SGLang](llm-model/sglang.md) - Efficient LLM serving with RadixAttention
+- [TGI](llm-model/tgi.md) - HuggingFace Text Generation Inference
+- [Ollama](llm-model/ollama.md) - Local LLM serving made simple
+
+### Embedding Model
+- [TEI](embedding-model/tei.md) - Text Embeddings Inference for vector generation
+
+### Guardrail
+- [Guardrails AI](guardrail/guardrails-ai.md) - LLM output validation and content safety
+
+### Observability
+- [Langfuse](observability/langfuse.md) - LLM observability and analytics
+- [MLflow](observability/mlflow.md) - ML experiment tracking and model registry
+- [Phoenix](observability/phoenix.md) - LLM observability and tracing
+
+### GUI Application
+- [Open WebUI](gui-app/openwebui.md) - ChatGPT-style web interface for LLMs
+
+### Vector Database
+- [Qdrant](vector-database/qdrant.md) - High-performance vector search engine
+- [Chroma](vector-database/chroma.md) - Open-source embedding database
+- [Milvus](vector-database/milvus.md) - Cloud-native vector database
+
+### Workflow Automation
+- [n8n](workflow-automation/n8n.md) - Visual workflow automation platform
+
+### AI Agent
+- [OpenClaw](ai-agent/openclaw.md) - AI agent orchestration bridge server
+
+## Configuration
+
+Components are configured via:
+
+1. **config.json** - Component-specific settings
+2. **.env** - Environment variables and credentials
+3. **config.local.json** - Local overrides (gitignored)
+4. **.env.local** - Local environment overrides (gitignored)
+
+Configuration hierarchy (later sources override earlier ones):
+```
+.env -> config.json -> .env.local -> config.local.json
+```
+
+## Architecture Patterns
+
+### Typical GenAI Stack
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Open WebUI (Frontend)                    │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│              LiteLLM (AI Gateway + Router)                   │
+└──┬────────────────┬────────────────┬────────────────────┬───┘
+   │                │                │                    │
+   ▼                ▼                ▼                    ▼
+┌─────────┐   ┌─────────┐   ┌─────────────┐   ┌──────────────┐
+│  vLLM   │   │ SGLang  │   │ AWS Bedrock │   │ Guardrails AI│
+└─────────┘   └─────────┘   └─────────────┘   └──────────────┘
+   │                │
+   ▼                ▼
+┌──────────────────────────────┐
+│    Langfuse (Observability)  │
+└──────────────────────────────┘
+```
+
+### RAG Application Stack
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Application Layer                        │
+└──────────────────────┬──────────────────────────────────────┘
+                       │
+┌──────────────────────▼──────────────────────────────────────┐
+│                    LiteLLM Gateway                           │
+└──┬────────────────────────────────────────────────────┬─────┘
+   │                                                     │
+   ▼                                                     ▼
+┌─────────────────┐                           ┌──────────────────┐
+│ LLM (vLLM/SGLang)│                          │  TEI (Embedding) │
+└─────────────────┘                           └────────┬─────────┘
+                                                       │
+                                                       ▼
+                                              ┌──────────────────┐
+                                              │ Vector DB (Qdrant)│
+                                              └──────────────────┘
+```
+
+## Learn More
+
+- [Getting Started Guide](../getting-started/quick-start.md)
+- [Security Best Practices](../reference/security.md)

--- a/docs/components/llm-model/ollama.md
+++ b/docs/components/llm-model/ollama.md
@@ -1,0 +1,173 @@
+# Ollama
+
+Run open-source LLMs locally with a simple API. Ollama bundles model weights, configurations, and runtime into a single package, making it easy to deploy and manage models on Kubernetes.
+
+| | |
+|---|---|
+| **Category** | llm-model |
+| **Official Docs** | [Ollama Documentation](https://ollama.com) |
+| **CLI Install** | `./cli llm-model ollama install` |
+| **CLI Uninstall** | `./cli llm-model ollama uninstall` |
+| **Namespace** | `ollama` |
+
+## Overview
+
+Ollama provides a lightweight runtime for running LLMs with:
+- **Simple Model Management**: Pull models with a single command
+- **OpenAI-Compatible API**: Drop-in replacement for OpenAI API
+- **GPU Acceleration**: Automatic GPU detection and utilization
+- **Model Library**: Access to a wide range of pre-packaged models
+- **Concurrent Models**: Run multiple models simultaneously
+- **Embedding Support**: Built-in embedding model support
+
+## Installation
+
+```bash
+./cli llm-model ollama install
+```
+
+The installer:
+1. Creates the `ollama` namespace and PVC for model storage
+2. Generates ConfigMap with selected model list
+3. Deploys Ollama server with GPU support
+4. Creates Service and Ingress
+5. Auto-pulls configured models on startup
+
+### Model Selection
+
+Models are configured as a simple list in `config.json`:
+
+```json
+{
+  "llm-model": {
+    "ollama": {
+      "models": [
+        "qwen3:32b",
+        "qwen3:30b",
+        "gemma3:27b",
+        "deepseek-r1:8b",
+        "nomic-embed-text:v1.5"
+      ]
+    }
+  }
+}
+```
+
+## Verification
+
+```bash
+# Check Ollama pods
+kubectl get pods -n ollama
+
+# Check service
+kubectl get svc -n ollama
+
+# Port-forward for testing
+kubectl port-forward svc/ollama 11434:11434 -n ollama --address 0.0.0.0 &
+
+# List models
+curl http://localhost:11434/api/tags
+
+# Test chat completion (OpenAI-compatible)
+curl http://localhost:11434/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3:32b",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
+
+# Test with Ollama native API
+curl http://localhost:11434/api/generate \
+  -d '{
+    "model": "qwen3:32b",
+    "prompt": "Explain quantum computing",
+    "stream": false
+  }'
+```
+
+## Configuration
+
+### Adding Models
+
+Edit `config.json` and reinstall:
+
+```json
+{
+  "llm-model": {
+    "ollama": {
+      "models": [
+        "qwen3:32b",
+        "my-new-model:latest"
+      ]
+    }
+  }
+}
+```
+
+```bash
+./cli llm-model ollama install
+```
+
+### Environment Variables
+
+The Ollama deployment automatically adapts to the EKS mode:
+
+| Variable | Description |
+|---|---|
+| `EKS_MODE` | `auto` or `standard` - affects Karpenter node selector prefix |
+| `DOMAIN` | Domain for ingress (optional) |
+
+## Integration with LiteLLM
+
+Ollama endpoints are automatically discovered by [LiteLLM](../ai-gateway/litellm.md):
+
+```yaml
+model_list:
+  - model_name: qwen3-32b-ollama
+    litellm_params:
+      model: ollama/qwen3:32b
+      api_base: http://ollama.ollama:11434
+```
+
+## Troubleshooting
+
+### Models not pulling
+
+```bash
+# Check init container logs (model pull happens at startup)
+kubectl logs -n ollama -l app=ollama -c init-pull
+
+# Check main container logs
+kubectl logs -n ollama -l app=ollama
+
+# Manually pull a model
+kubectl exec -it -n ollama <ollama-pod> -- ollama pull qwen3:32b
+```
+
+### Slow inference
+
+```bash
+# Check GPU is being used
+kubectl exec -it -n ollama <ollama-pod> -- nvidia-smi
+
+# Check if model fits in GPU memory
+kubectl exec -it -n ollama <ollama-pod> -- ollama ps
+```
+
+### PVC storage full
+
+```bash
+# Check PVC usage
+kubectl exec -it -n ollama <ollama-pod> -- df -h /root/.ollama
+
+# Remove unused models
+kubectl exec -it -n ollama <ollama-pod> -- ollama rm <model-name>
+```
+
+## Learn More
+
+- [Ollama Documentation](https://ollama.com)
+- [Ollama Model Library](https://ollama.com/library)
+- [Ollama API Reference](https://github.com/ollama/ollama/blob/main/docs/api.md)
+- [OpenAI Compatibility](https://github.com/ollama/ollama/blob/main/docs/openai.md)

--- a/docs/components/llm-model/sglang.md
+++ b/docs/components/llm-model/sglang.md
@@ -1,0 +1,307 @@
+# SGLang
+
+Fast LLM serving engine with RadixAttention for automatic KV cache reuse. Optimized for multi-turn conversations and structured generation workloads.
+
+| | |
+|---|---|
+| **Category** | llm-model |
+| **Official Docs** | [SGLang Documentation](https://docs.sglang.ai) |
+| **CLI Install** | `./cli llm-model sglang install` |
+| **CLI Uninstall** | `./cli llm-model sglang uninstall` |
+| **Namespace** | `sglang` |
+
+## Overview
+
+SGLang (Structured Generation Language) is a high-performance LLM serving engine featuring:
+- **RadixAttention**: Automatic KV cache reuse via radix tree structure
+- **Structured Generation**: JSON schema-constrained outputs
+- **Multi-Turn Optimization**: Efficient caching for conversational workloads
+- **Continuous Batching**: Dynamic request batching for higher throughput
+- **Tensor Parallel**: Distributed inference across multiple GPUs
+
+## Installation
+
+```bash
+./cli llm-model sglang install
+```
+
+The installer:
+1. Prompts for model selection from `config.json`
+2. Downloads model to PVC (if not cached)
+3. Deploys SGLang server with RadixAttention enabled
+4. Exposes OpenAI-compatible API endpoint
+
+### Model Selection
+
+Pre-configured models in `config.json`:
+
+```json
+{
+  "llm-model": {
+    "sglang": {
+      "models": [
+        { "name": "qwen3-30b-instruct-fp8", "deploy": true },
+        { "name": "qwen3-32b-fp8", "deploy": true },
+        { "name": "gpt-oss-20b", "deploy": false }
+      ]
+    }
+  }
+}
+```
+
+## Verification
+
+```bash
+# Check SGLang pods
+kubectl get pods -n sglang
+
+# Check service
+kubectl get svc -n sglang
+
+# Port-forward for testing
+kubectl port-forward svc/sglang 8000:8000 -n sglang --address 0.0.0.0 &
+
+# List models
+curl http://localhost:8000/v1/models
+
+# Test chat completion
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-30b-instruct-fp8",
+    "messages": [{"role": "user", "content": "Explain quantum computing"}],
+    "max_tokens": 200
+  }'
+```
+
+## Configuration
+
+### RadixAttention
+
+RadixAttention is enabled by default and automatically caches KV states in a radix tree structure. This provides:
+- **Automatic prefix matching**: Shared prompt prefixes reuse cached KV blocks
+- **Multi-turn efficiency**: Conversation history cached without manual management
+- **Zero configuration**: No need to specify cache keys or session IDs
+
+### SGLang Arguments
+
+Common arguments configured via installer:
+
+```bash
+# Tensor parallel size
+--tp 2
+
+# Memory fraction
+--mem-fraction-static 0.85
+
+# Context length
+--context-length 8192
+
+# Disable RadixAttention (not recommended)
+--disable-radix-cache
+
+# Chunked prefill
+--chunked-prefill-size 4096
+```
+
+## Advanced Features
+
+### Structured Generation
+
+Constrain outputs to JSON schema:
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-30b-instruct-fp8",
+    "messages": [
+      {"role": "user", "content": "Generate a person profile"}
+    ],
+    "response_format": {
+      "type": "json_schema",
+      "json_schema": {
+        "name": "person",
+        "schema": {
+          "type": "object",
+          "properties": {
+            "name": {"type": "string"},
+            "age": {"type": "integer"},
+            "occupation": {"type": "string"}
+          },
+          "required": ["name", "age"]
+        }
+      }
+    }
+  }'
+```
+
+### Regex-Constrained Generation
+
+Force outputs to match regex patterns:
+
+```python
+import requests
+
+response = requests.post(
+    "http://localhost:8000/generate",
+    json={
+        "text": "Generate a phone number: ",
+        "sampling_params": {
+            "max_new_tokens": 20,
+            "regex": r"\d{3}-\d{3}-\d{4}"  # Format: 123-456-7890
+        }
+    }
+)
+```
+
+### Multi-Turn Conversations
+
+RadixAttention automatically optimizes multi-turn conversations:
+
+```python
+import openai
+
+client = openai.OpenAI(
+    api_key="EMPTY",
+    base_url="http://localhost:8000/v1"
+)
+
+messages = [
+    {"role": "user", "content": "What is the capital of France?"}
+]
+
+# Turn 1
+response = client.chat.completions.create(
+    model="qwen3-30b-instruct-fp8",
+    messages=messages
+)
+messages.append({"role": "assistant", "content": response.choices[0].message.content})
+
+# Turn 2 - conversation history automatically cached
+messages.append({"role": "user", "content": "What is its population?"})
+response = client.chat.completions.create(
+    model="qwen3-30b-instruct-fp8",
+    messages=messages
+)
+```
+
+## Model Management
+
+### Add New Model
+
+1. Edit `config.json`:
+```json
+{
+  "llm-model": {
+    "sglang": {
+      "models": [
+        { "name": "my-new-model", "deploy": true }
+      ]
+    }
+  }
+}
+```
+
+2. Create model config at `components/llm-model/sglang/models/my-new-model.yaml`:
+```yaml
+modelId: "organization/model-name"
+servedModelName: "my-new-model"
+tensorParallelSize: 1
+memFractionStatic: 0.85
+contextLength: 8192
+```
+
+3. Reinstall:
+```bash
+./cli llm-model sglang install
+```
+
+## Integration with LiteLLM
+
+SGLang endpoints are automatically discovered by [LiteLLM](../ai-gateway/litellm.md):
+
+```yaml
+model_list:
+  - model_name: qwen3-30b-instruct-fp8-sglang
+    litellm_params:
+      model: openai/qwen3-30b-instruct-fp8
+      api_base: http://sglang.sglang:8000/v1
+```
+
+## Performance Tuning
+
+### Memory Optimization
+
+```bash
+# Reduce static memory fraction (leave more for KV cache)
+--mem-fraction-static 0.80
+
+# Smaller context length
+--context-length 4096
+```
+
+### Throughput Optimization
+
+```bash
+# Enable chunked prefill for long prompts
+--chunked-prefill-size 8192
+
+# Larger batch size (more memory usage)
+--max-running-requests 512
+```
+
+### Latency Optimization
+
+RadixAttention automatically optimizes TTFT for repeated prompts. For first-time prompts:
+
+```bash
+# Enable chunked prefill
+--chunked-prefill-size 4096
+```
+
+## Troubleshooting
+
+### OOM (Out of Memory)
+
+```bash
+# Reduce memory fraction
+--mem-fraction-static 0.75
+
+# Reduce context length
+--context-length 4096
+
+# Use smaller TP size (if multi-GPU)
+--tp 1
+```
+
+### Cache not working
+
+```bash
+# Check RadixAttention is enabled (should NOT see this flag)
+--disable-radix-cache
+
+# Check logs for cache hit statistics
+kubectl logs -n sglang -l app=sglang | grep "cache_hit"
+```
+
+### Model download fails
+
+```bash
+# Check PVC exists and is bound
+kubectl get pvc -n sglang
+
+# Check HuggingFace token
+kubectl get secret -n sglang huggingface-secret
+
+# Manual download
+kubectl exec -it -n sglang <sglang-pod> -- bash
+huggingface-cli download <model-id> --local-dir /models/<model-name>
+```
+
+## Learn More
+
+- [SGLang Documentation](https://docs.sglang.ai)
+- [RadixAttention Paper](https://arxiv.org/abs/2312.07104)
+- [Structured Generation Guide](https://docs.sglang.ai/en/latest/structured_generation.html)
+- [Supported Models List](https://docs.sglang.ai/en/latest/supported_models.html)

--- a/docs/components/llm-model/tgi.md
+++ b/docs/components/llm-model/tgi.md
@@ -1,0 +1,165 @@
+# TGI
+
+Text Generation Inference (TGI) is a high-performance inference server from Hugging Face, optimized for serving large language models with features like continuous batching, tensor parallelism, and quantization.
+
+| | |
+|---|---|
+| **Category** | llm-model |
+| **Official Docs** | [TGI Documentation](https://huggingface.co/docs/text-generation-inference) |
+| **CLI Install** | `./cli llm-model tgi install` |
+| **CLI Uninstall** | `./cli llm-model tgi uninstall` |
+| **Namespace** | `tgi` |
+
+## Overview
+
+TGI is Hugging Face's production-ready inference server for LLMs. Key features:
+- **Continuous Batching**: Dynamic request batching for optimal GPU utilization
+- **Tensor Parallelism**: Distribute models across multiple GPUs
+- **Quantization**: GPTQ, AWQ, and bitsandbytes support
+- **Flash Attention**: Optimized attention kernels for faster inference
+- **Token Streaming**: Server-sent events for real-time token generation
+- **Neuron Support**: AWS Inferentia2/Trainium accelerators
+
+## Installation
+
+```bash
+./cli llm-model tgi install
+```
+
+The installer:
+1. Creates the `tgi` namespace
+2. Sets up PVC for HuggingFace model cache
+3. Configures HuggingFace token secret
+4. Deploys selected models from `config.json`
+
+### Prerequisites
+
+- `HF_TOKEN` environment variable set in `.env` (required for gated models)
+
+### Model Selection
+
+Pre-configured models in `config.json`:
+
+```json
+{
+  "llm-model": {
+    "tgi": {
+      "models": [
+        { "name": "deepseek-r1-qwen3-8b", "deploy": false },
+        { "name": "qwen3-8b", "deploy": false },
+        { "name": "qwen3-8b-fp8", "deploy": false }
+      ]
+    }
+  }
+}
+```
+
+## Verification
+
+```bash
+# Check TGI pods
+kubectl get pods -n tgi
+
+# Check service
+kubectl get svc -n tgi
+
+# Port-forward for testing
+kubectl port-forward svc/tgi 8080:8080 -n tgi --address 0.0.0.0 &
+
+# Test text generation
+curl http://localhost:8080/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "tgi",
+    "messages": [{"role": "user", "content": "Hello!"}],
+    "max_tokens": 50
+  }'
+```
+
+## Configuration
+
+### Model Templates
+
+Each model has a template file at `components/llm-model/tgi/model-<name>.template.yaml` that defines:
+- Model ID (HuggingFace repository)
+- Resource requests (GPU, memory)
+- TGI server arguments
+- Node selectors
+
+### Environment Variables
+
+Configure in `.env`:
+
+```bash
+# Required for gated models
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxx
+```
+
+## Model Management
+
+```bash
+# Configure models
+./cli llm-model tgi configure-models
+
+# Add models
+./cli llm-model tgi add-models
+
+# Update models
+./cli llm-model tgi update-models
+
+# Remove all models
+./cli llm-model tgi remove-all-models
+```
+
+## Integration with LiteLLM
+
+TGI endpoints are automatically discovered by [LiteLLM](../ai-gateway/litellm.md):
+
+```yaml
+model_list:
+  - model_name: qwen3-8b-tgi
+    litellm_params:
+      model: openai/qwen3-8b
+      api_base: http://qwen3-8b.tgi:8080/v1
+```
+
+## Troubleshooting
+
+### Model download fails
+
+```bash
+# Check PVC exists and is bound
+kubectl get pvc -n tgi
+
+# Check HuggingFace token
+kubectl get secret -n tgi huggingface-secret
+
+# Check pod logs for download progress
+kubectl logs -n tgi -l app=tgi -f
+```
+
+### OOM (Out of Memory)
+
+```bash
+# Check pod events
+kubectl describe pod -n tgi -l app=tgi
+
+# Try quantized model variant (e.g., fp8)
+# Or increase GPU node instance type
+```
+
+### Pod stuck in Pending
+
+```bash
+# Check if GPU nodes are available
+kubectl get nodes -l nvidia.com/gpu.present=true
+
+# Check Karpenter provisioning
+kubectl logs -n kube-system -l app.kubernetes.io/name=karpenter
+```
+
+## Learn More
+
+- [TGI Documentation](https://huggingface.co/docs/text-generation-inference)
+- [TGI GitHub Repository](https://github.com/huggingface/text-generation-inference)
+- [Supported Models](https://huggingface.co/docs/text-generation-inference/supported_models)

--- a/docs/components/llm-model/vllm.md
+++ b/docs/components/llm-model/vllm.md
@@ -1,0 +1,338 @@
+# vLLM
+
+High-throughput LLM serving engine with PagedAttention for efficient memory management. Supports continuous batching, prefix caching, multi-LoRA, and quantization (FP8, GPTQ, AWQ).
+
+| | |
+|---|---|
+| **Category** | llm-model |
+| **Official Docs** | [vLLM Documentation](https://docs.vllm.ai) |
+| **CLI Install** | `./cli llm-model vllm install` |
+| **CLI Uninstall** | `./cli llm-model vllm uninstall` |
+| **Namespace** | `vllm` |
+
+## Overview
+
+vLLM is a fast and memory-efficient inference engine for large language models. Key features:
+- **PagedAttention**: Efficient KV cache management inspired by virtual memory paging
+- **Continuous Batching**: Dynamic request batching for higher throughput
+- **Prefix Caching**: Cache common prompt prefixes to reduce TTFT
+- **Quantization Support**: FP8, GPTQ, AWQ, SqueezeLLM
+- **Multi-LoRA**: Serve multiple LoRA adapters on a single base model
+- **Tensor/Pipeline Parallel**: Distributed inference across multiple GPUs
+- **Neuron Support**: AWS Inferentia2/Trainium accelerators
+
+## Installation
+
+```bash
+./cli llm-model vllm install
+```
+
+The installer:
+1. Prompts for model selection from `config.json`
+2. Downloads model to PVC (if not cached)
+3. Deploys vLLM server with optimal settings
+4. Exposes OpenAI-compatible API endpoint
+
+### Model Selection
+
+Pre-configured models in `config.json`:
+
+```json
+{
+  "llm-model": {
+    "vllm": {
+      "models": [
+        { "name": "qwen3-30b-instruct-fp8", "deploy": true },
+        { "name": "qwen3-32b-fp8", "deploy": true },
+        { "name": "deepseek-r1-qwen3-8b", "deploy": false },
+        { "name": "qwen3-8b-neuron", "deploy": false }
+      ]
+    }
+  }
+}
+```
+
+## Verification
+
+```bash
+# Check vLLM pods
+kubectl get pods -n vllm
+
+# Check service
+kubectl get svc -n vllm
+
+# Port-forward for testing
+kubectl port-forward svc/vllm 8000:8000 -n vllm --address 0.0.0.0 &
+
+# List models
+curl http://localhost:8000/v1/models
+
+# Test completion
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-30b-instruct-fp8",
+    "prompt": "Once upon a time",
+    "max_tokens": 50
+  }'
+
+# Test chat completion
+curl http://localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "qwen3-30b-instruct-fp8",
+    "messages": [{"role": "user", "content": "Explain quantum computing"}],
+    "max_tokens": 200
+  }'
+```
+
+## Configuration
+
+### Model Download
+
+Models are downloaded to PVC during installation:
+
+- **Storage**: Uses platform-specific StorageClass (NFS for K8s, EFS for EKS)
+- **Path**: `/models/<model-name>/`
+- **Auto-detection**: Skips download if model files exist
+
+### vLLM Arguments
+
+Common arguments configured via installer or `config.json`:
+
+```bash
+# GPU memory utilization
+--gpu-memory-utilization 0.90
+
+# Tensor parallel size (split model across N GPUs)
+--tensor-parallel-size 2
+
+# Max model length (context size)
+--max-model-len 8192
+
+# Quantization
+--quantization fp8
+
+# Block size (larger = more memory, fewer blocks)
+--block-size 128
+
+# Enable prefix caching
+--enable-prefix-caching
+```
+
+### Neuron Support
+
+For AWS Inferentia2/Trainium:
+
+```bash
+# Select Neuron-optimized model
+? Select model: qwen3-8b-neuron
+
+# vLLM automatically uses neuron backend
+--device neuron
+--tensor-parallel-size 2  # Neuron cores
+```
+
+## Advanced Features
+
+### Multi-LoRA Serving
+
+Serve multiple LoRA adapters on a single base model:
+
+```bash
+--enable-lora
+--max-loras 8
+--max-lora-rank 64
+```
+
+Then specify LoRA at request time:
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "base-model",
+    "prompt": "Once upon a time",
+    "lora_name": "my-lora-adapter"
+  }'
+```
+
+### Speculative Decoding
+
+Use smaller draft model to speed up generation:
+
+```bash
+--speculative-model <draft-model-id>
+--num-speculative-tokens 5
+```
+
+### Chunked Prefill
+
+Enable for long prompts (reduces TTFT at cost of throughput):
+
+```bash
+--enable-chunked-prefill
+--max-num-batched-tokens 8192
+```
+
+### Quantization
+
+#### FP8 (H100/H200)
+
+```bash
+--quantization fp8
+# Requires FP8 checkpoint or runtime quantization
+```
+
+#### GPTQ
+
+```bash
+--quantization gptq
+# Model must be pre-quantized to GPTQ format
+```
+
+#### AWQ
+
+```bash
+--quantization awq
+# Model must be pre-quantized to AWQ format
+```
+
+## Model Management
+
+### List Downloaded Models
+
+```bash
+kubectl exec -it -n vllm <vllm-pod> -- ls /models
+```
+
+### Add New Model
+
+1. Edit `config.json`:
+```json
+{
+  "llm-model": {
+    "vllm": {
+      "models": [
+        { "name": "my-new-model", "deploy": true }
+      ]
+    }
+  }
+}
+```
+
+2. Create model config at `components/llm-model/vllm/models/my-new-model.yaml`:
+```yaml
+modelId: "organization/model-name"
+servedModelName: "my-new-model"
+tensorParallelSize: 1
+gpuMemoryUtilization: 0.90
+maxModelLen: 8192
+```
+
+3. Reinstall:
+```bash
+./cli llm-model vllm install
+```
+
+## Integration with LiteLLM
+
+vLLM endpoints are automatically discovered by [LiteLLM](../ai-gateway/litellm.md):
+
+```yaml
+model_list:
+  - model_name: qwen3-30b-instruct-fp8
+    litellm_params:
+      model: openai/qwen3-30b-instruct-fp8
+      api_base: http://vllm.vllm:8000/v1
+```
+
+## Performance Tuning
+
+### Memory Optimization
+
+```bash
+# Increase GPU memory for KV cache
+--gpu-memory-utilization 0.95
+
+# Reduce block size (more blocks, less memory per block)
+--block-size 64
+
+# Enable CPU offloading
+--cpu-offload-gb 16
+```
+
+### Throughput Optimization
+
+```bash
+# Increase max parallel requests
+--max-num-seqs 256
+
+# Larger block size
+--block-size 128
+
+# Disable unnecessary features
+--disable-log-requests
+```
+
+### Latency Optimization
+
+```bash
+# Enable prefix caching
+--enable-prefix-caching
+
+# Chunked prefill for long prompts
+--enable-chunked-prefill
+
+# Speculative decoding
+--speculative-model <draft-model>
+```
+
+## Troubleshooting
+
+### OOM (Out of Memory)
+
+```bash
+# Reduce GPU memory utilization
+--gpu-memory-utilization 0.80
+
+# Reduce max model length
+--max-model-len 4096
+
+# Use quantization
+--quantization fp8
+```
+
+### Low throughput
+
+```bash
+# Check logs for warnings
+kubectl logs -n vllm -l app=vllm
+
+# Increase max num seqs
+--max-num-seqs 512
+
+# Check GPU utilization
+kubectl exec -it -n vllm <vllm-pod> -- nvidia-smi
+```
+
+### Model download fails
+
+```bash
+# Check PVC exists and is bound
+kubectl get pvc -n vllm
+
+# Check HuggingFace token (for gated models)
+kubectl get secret -n vllm huggingface-secret
+
+# Manual download
+kubectl exec -it -n vllm <vllm-pod> -- bash
+huggingface-cli download <model-id> --local-dir /models/<model-name>
+```
+
+## Learn More
+
+- [vLLM Documentation](https://docs.vllm.ai)
+- [vLLM Performance Benchmarks](https://docs.vllm.ai/en/latest/performance_benchmark/benchmarks.html)
+- [PagedAttention Paper](https://arxiv.org/abs/2309.06180)
+- [Supported Models List](https://docs.vllm.ai/en/latest/models/supported_models.html)

--- a/docs/components/nvidia-platform/aiconfigurator.md
+++ b/docs/components/nvidia-platform/aiconfigurator.md
@@ -1,0 +1,248 @@
+# AIConfigurator
+
+Automatically recommend optimal parallelization (TP/PP) and deployment configuration using NVIDIA AI Configurator simulation. Compares aggregated vs disaggregated serving and generates Pareto frontiers.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [NVIDIA AI Configurator](https://docs.nvidia.com/ai-configurator/) |
+| **CLI Install** | `./cli nvidia-platform aiconfigurator install` |
+| **CLI Uninstall** | `./cli nvidia-platform aiconfigurator uninstall` |
+| **Namespace** | `dynamo-system` |
+
+## Overview
+
+AIConfigurator eliminates guesswork in LLM deployment configuration by:
+- **Quick Estimate**: Fast TP/PP recommendation (~25s, no GPU required)
+- **SLA-Driven Deploy**: Auto-profile + plan + deploy via DGDR (~5min AIC / 2-4h Real)
+
+Both modes use simulation or profiling to find optimal configurations under SLA constraints (latency, throughput).
+
+## Installation
+
+```bash
+./cli nvidia-platform aiconfigurator install
+```
+
+The installer prompts for mode selection and configuration.
+
+## Modes
+
+| Mode | Description | Duration | GPU Required | Deploys |
+|------|-------------|----------|:------------:|:-------:|
+| **Quick Estimate** | `aiconfigurator cli default` — agg vs disagg Pareto comparison | ~25s | No | No |
+| **SLA-Driven Deploy** | profile (AIC or real engine) + plan + deploy via DGDR | AIC ~5min / Real 2-4h | No (AIC) / Yes (Real) | Yes |
+
+## Quick Estimate
+
+Uses `aiconfigurator cli default` via a dedicated pod to:
+1. Load model architecture from `model_configs/` (pre-cached HuggingFace configs)
+2. Sweep TP=1,2,4,8 for both agg and disagg modes
+3. Display Pareto frontier (ASCII art) + top configurations table
+4. Recommend best agg and disagg configs under SLA constraints
+
+### Example Output
+
+```
+Best Experiment Chosen: agg at 1604.74 tokens/s/gpu (disagg 0.72x better)
+
+agg Top Configurations:
+| Rank | tokens/s/gpu | TTFT   | parallel | replicas |
+|  1   |   1604.74    | 84.42  | tp4pp1   |    2     |
+|  2   |   1574.83    | 86.39  | tp2pp1   |    4     |
+
+disagg Top Configurations:
+| Rank | tokens/s/gpu | TTFT   | (p)parallel | (d)parallel | (p)workers | (d)workers |
+|  1   |   1149.49    | 45.10  | tp1pp1      | tp2pp1      |     2      |     3      |
+```
+
+!!! info "FP8 Quantization"
+    AIConfigurator uses FP8 GEMM + FP8 KV cache by default on H100/H200 (hardware-optimal). Quantization is determined by the system/backend combination, not the model name.
+
+### Interactive Prompts
+
+```
+? Select mode: Quick Estimate
+? Select GPU system: H100 SXM / H200 SXM / A100 SXM / B200 SXM / GB200 SXM
+? Select backend: vLLM 0.12.0 / TRT-LLM 1.2.0rc5 / SGLang 0.5.6.post2
+? Select model from supported list: [dynamic list from model_configs/]
+? Max TTFT (ms): 100
+? Min throughput (tokens/s): 1000
+```
+
+### Supported Configurations (AIC)
+
+| GPU System | vLLM | TRT-LLM | SGLang |
+|------------|:----:|:-------:|:------:|
+| H100 SXM | 0.12.0 | 1.0.0rc3, 1.2.0rc5 | 0.5.6.post2 |
+| H200 SXM | 0.12.0 | 1.0.0rc3, 1.2.0rc5 | 0.5.6.post2 |
+| A100 SXM | 0.12.0 | 1.0.0 | — |
+| B200 SXM | — | 1.0.0rc3, 1.2.0rc5 | 0.5.6.post2 |
+| GB200 SXM | — | 1.0.0rc3, 1.2.0rc5 | — |
+
+Model list is **dynamically retrieved** from `model_configs/` (22+ models including Qwen, Llama, Mixtral, DeepSeek, Nemotron).
+
+## SLA-Driven Deploy (DGDR)
+
+Creates a `DynamoGraphDeploymentRequest` (DGDR) that the Dynamo Operator processes automatically.
+
+### Profiling Methods
+
+| Method | When to Use | Duration | GPU |
+|--------|-------------|----------|:---:|
+| **AIC Simulation** | Model in AIC support list | ~5 min | No |
+| **Real Engine Profiling** | Any HuggingFace model | 2-4 hours | Yes (via DGD) |
+
+- **AIC**: Select GPU system → backend → model from supported list. Fast simulation, no GPU required.
+- **Real**: Select backend → enter HuggingFace model ID (e.g., `Qwen/Qwen3-30B-A3B-Instruct-2507-FP8`). The profiler orchestrates temporary DGDs to benchmark with AIPerf.
+
+### DGDR Flow
+
+```
+DGDR Created → Pending → Profiling → [complete] → Deploying → Ready
+                                         │
+                    AIC simulation or     │
+                    Real engine profiling  │
+                                          ▼
+                              DGD created (independent of DGDR)
+                              + planner-profile-data ConfigMap
+```
+
+### Interactive Prompts
+
+```
+? Select mode: SLA-Driven Deploy
+? Profiling method: AIC Simulation / Real Engine Profiling
+? DGDR name: qwen3-30b-sla
+? Auto-deploy after profiling with SLA-based planner? Yes
+? Min GPUs per engine (0 = auto): 0
+? Max GPUs per engine (0 = auto): 0
+```
+
+### Auto-Configuration
+
+No prompts for these settings:
+
+| Setting | Value | Reason |
+|---------|-------|--------|
+| Model cache PVC | `dynamo-model-cache` (auto-create if missing) | Same PVC as dynamo-vllm |
+| PVC mount path | `/opt/models` | Matches dynamo-vllm mount path |
+| Model path in PVC | `<model_id>` | `mountPath/pvcPath` = `/opt/models/<model>` |
+| Discovery backend | `etcd` (via DGD annotation) | Required for KVBM handshake stability |
+| SLA Planner min endpoints | `1` | Minimum 1 prefill + 1 decode replica |
+| SLA Planner adjustment interval | `60s` | Scaling check frequency |
+| Profiling job resources | 2-4 CPU, 8-16Gi memory | Profiler is orchestrator only |
+
+## DGDR Lifecycle
+
+### States
+
+| State | Description |
+|-------|-------------|
+| Pending | Spec validated, preparing profiling job |
+| Profiling | Profiling job running |
+| Deploying | autoApply=true, creating DGD |
+| Ready | DGD deployed successfully |
+| DeploymentDeleted | DGD was manually deleted; create new DGDR to redeploy |
+| Failed | Error at any stage |
+
+### DGD Independence
+
+- **DGD is NOT owned by DGDR**: Deleting DGDR does not delete the DGD (protects serving traffic)
+- **ConfigMap persistence**: `profiling-output-<dgdr>` and `planner-profile-data` survive DGDR deletion
+- **Immutable**: Once profiling starts, spec cannot be changed. Create a new DGDR to change config.
+
+### Re-Deploy from ConfigMap
+
+Extract DGD YAML from ConfigMap and apply without re-profiling:
+
+```bash
+kubectl get cm profiling-output-<dgdr-name> -n dynamo-system \
+  -o jsonpath='{.data.config_with_planner\.yaml}' > my-dgd.yaml
+kubectl apply -f my-dgd.yaml -n dynamo-system
+```
+
+## Verification
+
+```bash
+# Check DGDR status
+kubectl get dynamographdeploymentrequest -n dynamo-system
+
+# Check profiling job
+kubectl get jobs -n dynamo-system | grep aiconfigurator
+
+# Check profiling logs
+kubectl logs -n dynamo-system -l job-name=aiconfigurator-<dgdr-name> -f
+
+# Check created DGD (after profiling completes)
+kubectl get dynamographdeployment -n dynamo-system
+
+# Check ConfigMaps
+kubectl get cm -n dynamo-system | grep profiling-output
+```
+
+## Configuration
+
+DGDR configuration is managed through interactive prompts. Common settings:
+
+| Parameter | Description | Typical Values |
+|-----------|-------------|----------------|
+| Auto-deploy | Create DGD automatically after profiling | Yes / No |
+| Min GPUs per engine | Minimum GPU allocation | 0 (auto), 1, 2, 4 |
+| Max GPUs per engine | Maximum GPU allocation | 0 (auto), 8, 16 |
+| Max TTFT | Time to First Token SLA (ms) | 50, 100, 200 |
+| Min Throughput | Minimum tokens/s | 1000, 5000, 10000 |
+
+## Real Engine Profiling
+
+For models not in the AIC support list, use Real Engine Profiling:
+
+1. Installer creates temporary DGDs with different TP/PP configurations
+2. Runs AIPerf benchmarks on each configuration
+3. Collects metrics (TTFT, ITL, throughput)
+4. Generates optimal configuration recommendation
+5. Creates final DGD with SLA Planner
+
+!!! warning "Long Duration"
+    Real Engine Profiling takes 2-4 hours and requires GPU resources. Plan accordingly.
+
+## Troubleshooting
+
+### Quick Estimate pod fails
+
+```bash
+# Check pod logs
+kubectl logs -n dynamo-system -l app=aiconfigurator
+
+# Check model_configs availability
+kubectl exec -it -n dynamo-system <aiconfigurator-pod> -- ls /app/model_configs
+```
+
+### DGDR stuck in Profiling
+
+```bash
+# Check profiling job
+kubectl get jobs -n dynamo-system | grep aiconfigurator
+
+# Check profiling logs
+kubectl logs -n dynamo-system -l job-name=aiconfigurator-<dgdr-name> -f
+
+# Check DGDR events
+kubectl describe dynamographdeploymentrequest -n dynamo-system <dgdr-name>
+```
+
+### DGD not created after profiling
+
+```bash
+# Check DGDR status
+kubectl get dynamographdeploymentrequest -n dynamo-system <dgdr-name> -o yaml
+
+# Check ConfigMap has DGD spec
+kubectl get cm profiling-output-<dgdr-name> -n dynamo-system -o yaml
+```
+
+## Learn More
+
+- [NVIDIA AI Configurator Documentation](https://docs.nvidia.com/ai-configurator/)
+- [Dynamo Platform SLA Planner](dynamo-platform.md)
+- [AIPerf Benchmark Integration](benchmark.md)

--- a/docs/components/nvidia-platform/benchmark.md
+++ b/docs/components/nvidia-platform/benchmark.md
@@ -1,0 +1,205 @@
+# AIPerf Benchmark
+
+Comprehensive LLM benchmarking suite for measuring throughput, latency, and efficiency across different concurrency levels and workload patterns. Results are automatically pushed to Prometheus Pushgateway and visualized in Grafana.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [NVIDIA AIPerf](https://github.com/NVIDIA/AIPerf) |
+| **CLI Install** | `./cli nvidia-platform benchmark install` |
+| **CLI Uninstall** | `./cli nvidia-platform benchmark uninstall` |
+| **Namespace** | `dynamo-system` |
+
+## Overview
+
+AIPerf Benchmark provides automated performance testing for Dynamo vLLM deployments with:
+- **Concurrency Sweep**: Throughput vs latency at different load levels
+- **Multi-Turn**: Session affinity testing for KV Router cache hits
+- **Sequence Distribution**: Mixed workload simulation (QA + summarization)
+- **Prefix Cache**: Synthetic shared-prefix workload for KV cache testing
+
+Results are stored in PVC, pushed to Prometheus, and visualized in the **Benchmark Pareto** Grafana dashboard.
+
+## Installation
+
+```bash
+./cli nvidia-platform benchmark install
+```
+
+### Interactive Prompts
+
+The installer guides you through benchmark configuration:
+
+1. **Select DynamoGraphDeployment**: Choose from deployed models
+2. **Choose benchmark mode**: Concurrency Sweep / Multi-Turn / Seq Distribution / Prefix Cache
+3. **Set parameters**: ISL, OSL, concurrency levels, request count
+
+### Benchmark Modes
+
+| Mode | Description | Use Case |
+|------|-------------|----------|
+| **Concurrency Sweep** | Throughput vs latency at different concurrency levels (1, 8, 16, 32, 64, ...) | Baseline performance comparison |
+| **Multi-Turn** | Multi-turn conversations with session affinity | KV Router cache hit effect |
+| **Sequence Distribution** | Mixed ISL/OSL workloads (QA + summarization) | Real-world traffic simulation |
+| **Prefix Cache** | Synthetic shared-prefix workload (no trace file) | KV cache hit rate testing |
+
+!!! info "Prefix Cache Mode"
+    `request_count` is automatically set to **concurrency × 4** per level (aiperf requires `request_count >= concurrency`). No manual prompt for request count.
+
+## Running a Benchmark
+
+```bash
+# Start benchmark
+./cli nvidia-platform benchmark install
+
+# Follow prompts to configure
+# Example: Concurrency Sweep
+? Select deployment: qwen3-30b-fp8
+? Benchmark mode: Concurrency Sweep
+? Input Sequence Length (ISL): 256
+? Output Sequence Length (OSL): 256
+? Concurrency levels (comma-separated): 1,8,16,32
+? Benchmark name: qwen3-sweep-256-256
+
+# Monitor progress
+kubectl logs -n dynamo-system -l job-name=aiperf-benchmark-<name> -f
+
+# Check completion
+kubectl get jobs -n dynamo-system
+```
+
+## Results
+
+After benchmark completion:
+
+1. **PVC Storage**: Results stored in `benchmark-results` PVC under `dynamo-system` namespace
+   - Per-benchmark directories: `c1`, `c8`, `c16`, `c32`
+   - CSV files with detailed metrics
+2. **Local Copy**: Results copied to `components/nvidia-platform/benchmark/results/<benchmark-name>/`
+3. **Prometheus Metrics**: Automatically pushed to Pushgateway (scraped by Prometheus)
+4. **Grafana Dashboard**: View in **Benchmark Pareto** dashboard
+
+## Grafana Visualization
+
+Open Grafana → **Benchmark Pareto** dashboard:
+
+### Available Charts
+
+| Chart | Description | X-Axis | Y-Axis |
+|-------|-------------|--------|--------|
+| **TPS/GPU vs Concurrency** | Throughput per GPU | Concurrency | TPS/GPU |
+| **TPS/User vs Concurrency** | Per-user throughput | Concurrency | TPS/User |
+| **TTFT P50/P99 vs Concurrency** | Time to First Token latency | Concurrency | TTFT (ms) |
+| **ITL P50 vs Concurrency** | Inter-Token Latency | Concurrency | ITL (ms) |
+| **Request Latency P50 vs Concurrency** | End-to-end latency | Concurrency | Latency (ms) |
+| **GPU Efficiency (Pareto)** | TPS/GPU vs TPS/User scatter plot | TPS/User | TPS/GPU |
+
+### Comparing Deployments
+
+Run the same benchmark mode on different configurations to generate Pareto comparison:
+
+```bash
+# 1. Deploy agg baseline → run sweep → name: "qwen3-agg"
+./cli nvidia-platform dynamo-vllm install
+# Configure: mode=agg, TP=2, replicas=2
+./cli nvidia-platform benchmark install
+# Benchmark name: qwen3-agg
+
+# 2. Deploy agg + KV Router → run sweep → name: "qwen3-kvrouter"
+./cli nvidia-platform dynamo-vllm install
+# Configure: mode=agg, TP=2, replicas=2, KV Router=Yes
+./cli nvidia-platform benchmark install
+# Benchmark name: qwen3-kvrouter
+
+# 3. Deploy disagg + KVBM → run sweep → name: "qwen3-disagg"
+./cli nvidia-platform dynamo-vllm install
+# Configure: mode=disagg, Prefill TP=1, Decode TP=2, KVBM=Yes
+./cli nvidia-platform benchmark install
+# Benchmark name: qwen3-disagg
+```
+
+Then in Grafana, select all three benchmarks in the **Benchmark** dropdown to compare.
+
+### Reading the Pareto Chart
+
+The GPU Efficiency chart shows TPS/GPU (Y) vs TPS/User (X):
+- **Top-right**: Optimal (high throughput per GPU, high per-user throughput)
+- **Top-left**: High GPU efficiency, low user experience (under-provisioned)
+- **Bottom-right**: Low GPU efficiency, high user experience (over-provisioned)
+
+## Verification
+
+```bash
+# Check benchmark job
+kubectl get jobs -n dynamo-system | grep aiperf
+
+# Check results PVC
+kubectl get pvc -n dynamo-system benchmark-results
+
+# View results (mount PVC)
+kubectl run -it --rm debug --image=ubuntu --restart=Never \
+  --overrides='{"spec":{"volumes":[{"name":"results","persistentVolumeClaim":{"claimName":"benchmark-results"}}],"containers":[{"name":"debug","image":"ubuntu","command":["bash"],"volumeMounts":[{"name":"results","mountPath":"/results"}]}]}}'
+# Inside pod: ls /results
+```
+
+## Managing Benchmark Data
+
+### Delete Pushgateway Metrics
+
+To reset benchmark data in Grafana (clears all Pushgateway metrics):
+
+```bash
+kubectl port-forward svc/pushgateway-prometheus-pushgateway 19091:9091 -n monitoring &
+sleep 2
+curl -s http://localhost:19091/metrics | grep -oP 'job="[^"]*"' | sort -u | sed 's/job="//;s/"//' | while read job; do
+  curl -X DELETE "http://localhost:19091/metrics/job/$job"
+done
+pkill -f "port-forward.*pushgateway"
+```
+
+### Uninstall Benchmark Resources
+
+```bash
+# Removes Jobs and PVC
+./cli nvidia-platform benchmark uninstall
+```
+
+## Configuration
+
+Benchmark parameters are configured interactively. Common settings:
+
+| Parameter | Description | Typical Values |
+|-----------|-------------|----------------|
+| ISL | Input Sequence Length | 128, 256, 512, 1024 |
+| OSL | Output Sequence Length | 128, 256, 512 |
+| Concurrency Levels | Concurrent requests | 1,8,16,32,64,128 |
+| Request Count | Total requests per level | 100, 500, 1000 |
+
+## Troubleshooting
+
+### Benchmark job fails
+
+```bash
+# Check job logs
+kubectl logs -n dynamo-system -l job-name=aiperf-benchmark-<name>
+
+# Check PVC mount
+kubectl describe pvc benchmark-results -n dynamo-system
+```
+
+### Metrics not appearing in Grafana
+
+```bash
+# Check Pushgateway has data
+kubectl port-forward svc/pushgateway-prometheus-pushgateway 19091:9091 -n monitoring &
+curl http://localhost:19091/metrics | grep aiperf
+
+# Check Prometheus is scraping Pushgateway
+# Grafana → Explore → Prometheus → Query: {job=~"aiperf.*"}
+```
+
+## Learn More
+
+- [NVIDIA AIPerf Documentation](https://github.com/NVIDIA/AIPerf)
+- [Benchmark Pareto Dashboard Guide](monitoring.md#benchmark-pareto-dashboard)
+- [Prometheus Pushgateway](https://github.com/prometheus/pushgateway)

--- a/docs/components/nvidia-platform/dynamo-platform.md
+++ b/docs/components/nvidia-platform/dynamo-platform.md
@@ -1,0 +1,192 @@
+# Dynamo Platform
+
+NVIDIA Dynamo Platform provides orchestration, scheduling, and lifecycle management for LLM serving workloads. It includes CRDs, Operator, etcd, NATS, Grove KV Router, and KAI Scheduler.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [NVIDIA Dynamo Platform](https://docs.nvidia.com/dynamo/) |
+| **CLI Install** | `./cli nvidia-platform dynamo-platform install` |
+| **CLI Uninstall** | `./cli nvidia-platform dynamo-platform uninstall` |
+| **Namespace** | `dynamo-system` |
+
+## Overview
+
+The Dynamo Platform is the control plane for NVIDIA's LLM serving infrastructure. It manages:
+- **DynamoGraphDeployment (DGD)**: Declarative model deployment with aggregated/disaggregated modes
+- **DynamoGraphDeploymentRequest (DGDR)**: SLA-driven auto-configuration and deployment
+- **DynamoWorkerMetadata**: Worker state tracking and discovery
+- **Grove**: KV-aware request routing
+- **KAI Scheduler**: Intelligent GPU scheduling
+- **etcd**: Service discovery and state storage
+- **NATS**: Internal messaging bus
+
+## Installation
+
+```bash
+./cli nvidia-platform dynamo-platform install
+```
+
+### Auto-Configuration
+
+The installer automatically detects and configures:
+
+| Component | Detection | Action |
+|-----------|-----------|--------|
+| Prometheus | `monitoring` installed | Auto-configure `prometheusEndpoint` |
+| GPU Operator | Detected | Status check only |
+| StorageClass (K8s) | `local-path` not found | Auto-install local-path-provisioner |
+| Ingress (K8s) | Not found | Prompt to install |
+| EFS (EKS) | Not found | Auto-install EFS CSI Driver + StorageClass |
+
+### Platform-Specific Configuration
+
+**K8s Mode**:
+- Uses `nfs` StorageClass for model cache PVC (ReadWriteMany)
+- Uses `local-path` for etcd/NATS persistence (ReadWriteOnce)
+- Prompts to install `ingress-nginx` if not found
+
+**EKS Mode**:
+- Uses `efs` StorageClass for model cache PVC (ReadWriteMany)
+- Auto-installs EFS CSI Driver if not found
+- ALB Ingress annotations auto-added
+
+## Verification
+
+```bash
+# Check Dynamo Platform pods
+kubectl get pods -n dynamo-system
+
+# Check CRDs
+kubectl get crds | grep nvidia.com
+
+# Check etcd cluster
+kubectl get pods -n dynamo-system -l app.kubernetes.io/name=etcd
+
+# Check NATS
+kubectl get pods -n dynamo-system -l app.kubernetes.io/name=nats
+
+# Check Dynamo Operator
+kubectl logs -n dynamo-system -l app=dynamo-operator
+```
+
+Expected CRDs:
+- `dynamographdeployments.nvidia.com`
+- `dynamographdeploymentrequests.nvidia.com`
+- `dynamoworkermetadatas.nvidia.com`
+
+## Configuration
+
+Configuration is managed through `config.json`:
+
+```json
+{
+  "platform": {
+    "k8s": {
+      "storageClass": "nfs",
+      "dynamoPlatform": {
+        "releaseVersion": "0.9.0-post1",
+        "namespace": "dynamo-system",
+        "groveEnabled": true,
+        "kaiSchedulerEnabled": true
+      }
+    },
+    "eks": {
+      "storageClass": "efs",
+      "dynamoPlatform": {
+        "releaseVersion": "0.9.1",
+        "namespace": "dynamo-system",
+        "groveEnabled": true,
+        "kaiSchedulerEnabled": true
+      }
+    }
+  }
+}
+```
+
+## Storage Architecture
+
+The Dynamo Platform uses two different StorageClasses:
+
+| StorageClass | Purpose | Access Mode | Used By |
+|--------------|---------|-------------|---------|
+| `nfs` / `efs` | Model cache PVC | ReadWriteMany | Dynamo vLLM (model download) |
+| `local-path` | etcd, NATS persistence | ReadWriteOnce | etcd, NATS StatefulSets |
+
+## Components
+
+### Dynamo Operator
+
+The Operator reconciles `DynamoGraphDeployment` and `DynamoGraphDeploymentRequest` resources:
+- Creates Frontend + Worker Deployments/StatefulSets
+- Configures Prometheus PodMonitors
+- Sets worker environment variables (DYN_SYSTEM_PORT, structured logging)
+- Manages service discovery (etcd or kubernetes)
+
+### etcd Cluster
+
+Distributed key-value store for:
+- Service discovery (preferred over kubernetes-native for KVBM stability)
+- Worker metadata and health state
+- Configuration coordination
+
+### NATS
+
+Lightweight messaging system for:
+- Internal component communication
+- Event-driven orchestration
+- Worker state updates
+
+### Grove KV Router
+
+KV-aware request routing:
+- Routes requests to workers with cached KV blocks
+- Improves Time to First Token (TTFT)
+- Configurable temperature and overlap scoring
+
+### KAI Scheduler
+
+Intelligent GPU scheduling for:
+- Multi-instance GPU (MIG) workloads
+- Fractional GPU allocation
+- Resource optimization
+
+## Discovery Backends
+
+Dynamo Platform supports two discovery backends:
+
+| Backend | Description | Use Case |
+|---------|-------------|----------|
+| `etcd` | External etcd cluster | **Recommended** for KVBM stability in multi-replica disaggregated mode |
+| `kubernetes` | K8s-native discovery | Simpler setup, but may cause KVBM handshake failures |
+
+The CLI defaults to `etcd` for all deployments. DGDR templates include `nvidia.com/dynamo-discovery-backend: etcd` annotation.
+
+## Integration with Monitoring
+
+When [Monitoring](monitoring.md) is installed before Dynamo Platform:
+1. Installer detects Prometheus Service
+2. Sets `--set prometheusEndpoint=http://prometheus-kube-prometheus-prometheus.monitoring:9090`
+3. Dynamo Operator auto-creates PodMonitors
+4. Worker metrics endpoint auto-configured at `:9090/metrics`
+
+## Known Issues
+
+### CRD Chart Version Mismatch (v0.9.0)
+
+| Issue | Workaround |
+|-------|-----------|
+| CRD chart is `v0.9.0`, Platform chart is `v0.9.0-post1` | CLI strips `-postN` suffix when fetching CRD chart |
+| `DynamoWorkerMetadata` CRD missing from `v0.9.0` chart | CLI applies bundled CRD after Helm install |
+
+### Discovery Backend + KVBM (v0.9.0)
+
+| Issue | Workaround |
+|-------|-----------|
+| `discoveryBackend: kubernetes` causes KVBM handshake failures | Platform defaults to `discoveryBackend: etcd` |
+
+## Learn More
+
+- [NVIDIA Dynamo Platform Documentation](https://docs.nvidia.com/dynamo/)
+- [etcd Documentation](https://etcd.io/docs/)
+- [NATS Documentation](https://docs.nats.io/)

--- a/docs/components/nvidia-platform/dynamo-vllm.md
+++ b/docs/components/nvidia-platform/dynamo-vllm.md
@@ -1,0 +1,236 @@
+# Dynamo vLLM Serving
+
+Deploy vLLM models with NVIDIA Dynamo Platform orchestration. Supports aggregated and disaggregated serving modes, KV cache routing, KV cache offloading (KVBM), and advanced parallelism strategies.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [NVIDIA Dynamo vLLM](https://docs.nvidia.com/dynamo/), [vLLM](https://docs.vllm.ai) |
+| **CLI Install** | `./cli nvidia-platform dynamo-vllm install` |
+| **CLI Uninstall** | `./cli nvidia-platform dynamo-vllm uninstall` |
+| **Namespace** | `dynamo-system` |
+
+## Overview
+
+Dynamo vLLM provides high-performance LLM serving with:
+- **Aggregated mode**: Single worker handles prefill + decode
+- **Disaggregated mode**: Separate prefill and decode workers with NIXL KV transfer
+- **KV Cache Routing**: Routes requests to workers with cached KV blocks
+- **KV Cache Offloading (KVBM)**: GPU → CPU → Disk cache hierarchy
+- **Model pre-download**: Downloads to PVC before deployment
+- **Multi-node serving**: Tensor/Pipeline/Expert parallelism with pod replicas
+
+## Installation
+
+```bash
+./cli nvidia-platform dynamo-vllm install
+```
+
+### Interactive Configuration
+
+The installer prompts for essential configuration only:
+
+```
+? Enter model name: (Qwen/Qwen3-30B-A3B-Instruct-2507-FP8)
+? Select deployment mode: Aggregated / Disaggregated
+? Tensor Parallel Size (TP): 1
+? Enable KV Router? No
+? Enable KV Cache Offloading (KVBM)? No
+? Worker replicas: 1
+? Additional vLLM args: --gpu-memory-utilization 0.90 --block-size 128
+? Deployment name: (qwen3-30b-a3b-instruct-25)
+? What would you like to do? Deploy now / Review first / Save only
+```
+
+### Auto-Configuration
+
+No prompts for these settings (configured from `config.json` or auto-detection):
+
+| Setting | Source |
+|---------|--------|
+| vLLM image tag | `config.json` → `dynamoPlatform.releaseVersion` |
+| Structured logging | Auto-enable if monitoring installed |
+| KV Router temperature | `0.5` (Dynamo default) |
+| KV overlap score weight | `1.0` (Dynamo default) |
+| KVBM disk directory | `/tmp` (K8s) / `/mnt/nvme/kvbm_cache` (EKS) |
+| KVBM disk offload filter | `true` (default, protects SSD lifespan) |
+
+## Deployment Modes
+
+### Aggregated (agg)
+
+Single worker handles both prefill (prompt encoding) and decode (token generation):
+
+```
+Request → Frontend → VllmWorker (prefill + decode) → Response
+```
+
+**Characteristics**:
+- Simpler architecture
+- Lower latency for small batches
+- TP/PP/EP applied to single worker type
+- Better for single-turn conversations
+
+### Disaggregated (disagg)
+
+Separate workers for prefill and decode, with NIXL for KV transfer:
+
+```
+Request → Frontend → VllmPrefillWorker → [NIXL KV Transfer] → VllmDecodeWorker → Response
+```
+
+**Characteristics**:
+- Independent scaling of prefill and decode
+- Separate TP/PP/EP for each worker type
+- Better for multi-turn conversations with KV Router
+- KVBM applied to Prefill workers only
+
+## Parallelism
+
+| Parameter | Description | Agg | Disagg |
+|-----------|-------------|:---:|:------:|
+| **Tensor Parallel (TP)** | Split model across GPUs | Single setting | Separate Prefill TP + Decode TP |
+| **Pipeline Parallel (PP)** | Split layers across GPUs | Single setting | Separate Prefill PP + Decode PP |
+| **Expert Parallel (EP)** | MoE expert distribution | `--enable-expert-parallel` | Per worker type |
+| **Replicas** | Pod-level scaling | Worker replicas | Prefill replicas + Decode replicas |
+
+Example: Disaggregated with TP=2 for prefill, TP=4 for decode:
+```
+Prefill: 2 replicas × TP2 = 4 GPUs
+Decode:  4 replicas × TP4 = 16 GPUs
+Total: 20 GPUs
+```
+
+## KV Cache Routing
+
+Routes requests to workers with cached KV blocks for improved TTFT (Time to First Token).
+
+| Setting | ENV / Arg | Default |
+|---------|-----------|---------|
+| Enable | `DYN_ROUTER_MODE=kv` | Disabled |
+| Temperature | `DYN_ROUTER_TEMPERATURE` | 0.5 |
+| Overlap Weight | `DYN_KV_OVERLAP_SCORE_WEIGHT` | 1.0 |
+| KV Events | `--kv-events-config` | Auto when router enabled |
+
+**Use Case**: Multi-turn conversations with session affinity. Benchmark with [AIPerf Multi-Turn mode](benchmark.md).
+
+## KV Cache Offloading (KVBM)
+
+Three-tier cache hierarchy for larger effective context:
+
+```
+GPU Memory (G1) → CPU Pinned Memory (G2) → Local SSD/NVMe (G3)
+```
+
+| Setting | ENV | Description |
+|---------|-----|-------------|
+| CPU Cache | `DYN_KVBM_CPU_CACHE_GB` | CPU pinned memory size (GB) |
+| Disk Cache | `DYN_KVBM_DISK_CACHE_GB` | SSD cache size (GB) |
+| Disk Directory | `DYN_KVBM_DISK_CACHE_DIR` | Cache path (default: `/tmp`) |
+| Disk Offload Filter | `DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER` | Frequency filter (default: enabled) |
+| Connector | `--connector kvbm` (agg) / `--connector kvbm nixl` (disagg prefill) | Required |
+
+!!! warning "Disaggregated Mode"
+    In disaggregated mode, KVBM is applied to **Prefill workers only**. Decode workers use `--connector nixl` for KV transfer.
+
+!!! info "Disk Offload Frequency Filter"
+    Only offloads blocks with frequency >= 2 to disk, protecting SSD lifespan. Frequency doubles on cache hit, decays over time (600s interval).
+
+## Model Download
+
+Models are pre-downloaded to PVC using `huggingface_hub.snapshot_download`:
+
+- **Fixed path**: `/opt/models/<org>/<model-name>/`
+- **Auto-detection**: Checks if `*.safetensors` exist before download
+- **vLLM args**: `--model /opt/models/<org>/<model>` + `--served-model-name <HF ID>`
+
+Example:
+```
+Model: Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+PVC Path: /opt/models/Qwen/Qwen3-30B-A3B-Instruct-2507-FP8/
+vLLM: --model /opt/models/Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 --served-model-name Qwen/Qwen3-30B-A3B-Instruct-2507-FP8
+```
+
+## Verification
+
+```bash
+# Check deployment
+kubectl get dynamographdeployment -n dynamo-system
+
+# Check pods
+kubectl get pods -n dynamo-system
+
+# Check frontend service
+kubectl get svc -n dynamo-system | grep frontend
+
+# Port-forward for testing
+kubectl port-forward svc/<deployment>-frontend 8000:8000 -n dynamo-system --address 0.0.0.0 &
+
+# Auto-detect model name
+export MODEL=$(curl -s localhost:8000/v1/models | python3 -c "import sys,json; d=json.load(sys.stdin)['data']; print(d[0]['id'] if d else 'NONE')")
+
+# Test chat completion
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"$MODEL\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"Hello!\"}],
+    \"max_tokens\": 50,
+    \"stream\": false
+  }"
+```
+
+## Configuration
+
+Modify `config.json` to change default settings:
+
+```json
+{
+  "platform": {
+    "eks": {
+      "dynamoPlatform": {
+        "releaseVersion": "0.9.1"
+      }
+    }
+  }
+}
+```
+
+## Advanced vLLM Arguments
+
+Common arguments to pass via "Additional vLLM args":
+
+```bash
+# GPU memory utilization
+--gpu-memory-utilization 0.90
+
+# Block size (larger = more memory, fewer blocks)
+--block-size 128
+
+# Expert parallel (for MoE models)
+--enable-expert-parallel
+
+# Quantization
+--quantization fp8
+
+# Max model length
+--max-model-len 8192
+```
+
+## Integration with LiteLLM
+
+Deploy Dynamo vLLM models, then configure [LiteLLM](../ai-gateway/litellm.md) to route traffic:
+
+```yaml
+model_list:
+  - model_name: qwen3-30b-fp8
+    litellm_params:
+      model: openai/qwen3-30b-fp8
+      api_base: http://<deployment>-frontend.dynamo-system:8000/v1
+```
+
+## Learn More
+
+- [NVIDIA Dynamo Platform Documentation](https://docs.nvidia.com/dynamo/)
+- [vLLM Documentation](https://docs.vllm.ai)
+- [NIXL: Network-Integrated Execution Library](https://github.com/vllm-project/vllm/blob/main/docs/source/features/disaggregated_serving.md)

--- a/docs/components/nvidia-platform/gpu-operator.md
+++ b/docs/components/nvidia-platform/gpu-operator.md
@@ -1,0 +1,145 @@
+# NVIDIA GPU Operator
+
+The NVIDIA GPU Operator manages the lifecycle of NVIDIA GPU drivers, device plugins, and monitoring exporters on Kubernetes. It automates the deployment of all necessary components for running GPU workloads.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [GPU Operator Documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/) |
+| **CLI Install** | `./cli nvidia-platform gpu-operator install` |
+| **CLI Uninstall** | `./cli nvidia-platform gpu-operator uninstall` |
+| **Namespace** | `gpu-operator` |
+
+## Overview
+
+The GPU Operator simplifies GPU management in Kubernetes by deploying and managing:
+- GPU Feature Discovery (GFD) for node labeling
+- DCGM Exporter for GPU metrics
+- GPU Device Plugin for resource scheduling
+- GPU Driver (K8s mode only)
+- NVIDIA Container Toolkit (K8s mode only)
+
+## Installation
+
+```bash
+./cli nvidia-platform gpu-operator install
+```
+
+The installer automatically detects the platform mode (K8s or EKS) and configures components accordingly.
+
+### K8s Mode Configuration
+
+In K8s mode, the GPU Operator assumes drivers and Container Toolkit are pre-installed on worker nodes:
+
+- **Driver**: Disabled (requires NVIDIA Driver 580+ pre-installed)
+- **Toolkit**: Disabled (requires NVIDIA Container Toolkit with CDI configured)
+- **Device Plugin**: Disabled (CDI-based device management)
+- **GFD**: Enabled (GPU feature discovery)
+- **DCGM Exporter**: Enabled (GPU metrics for Prometheus)
+- **GDS**: Enabled (GPUDirect Storage)
+
+### EKS Mode Configuration
+
+In EKS mode, drivers and toolkit are provided by the EKS GPU AMI:
+
+- **Driver**: Disabled (provided by AMI)
+- **Toolkit**: Disabled (provided by AMI)
+- **Device Plugin**: Disabled (CDI-based device management)
+- **GFD**: Enabled (GPU feature discovery)
+- **DCGM Exporter**: Enabled (GPU metrics for Prometheus)
+- **GDS**: Enabled (GPUDirect Storage)
+
+## Verification
+
+```bash
+# Check GPU Operator pods
+kubectl get pods -n gpu-operator
+
+# Verify GPU resources are detected
+kubectl get nodes -o json | jq '.items[].status.capacity | select(."nvidia.com/gpu" != null)'
+
+# Check GPU labels
+kubectl get nodes --show-labels | grep nvidia.com/gpu
+
+# View DCGM Exporter metrics
+kubectl port-forward -n gpu-operator svc/gpu-operator-dcgm-exporter 9400:9400
+curl localhost:9400/metrics | grep DCGM
+```
+
+Expected output:
+```
+nvidia-gpu-operator-1234-abcd   1/1     Running   0          2m
+nvidia-gpu-operator-5678-efgh   1/1     Running   0          2m
+dcgm-exporter-1234              1/1     Running   0          2m
+gpu-feature-discovery-5678      1/1     Running   0          2m
+```
+
+## Configuration
+
+Configuration is managed through `config.json`:
+
+```json
+{
+  "platform": {
+    "eks": {
+      "gpuOperator": {
+        "driverEnabled": false,
+        "toolkitEnabled": false,
+        "devicePluginEnabled": false,
+        "gfdEnabled": true,
+        "dcgmExporterEnabled": true,
+        "gdsEnabled": true
+      }
+    },
+    "k8s": {
+      "gpuOperator": {
+        "driverEnabled": false,
+        "toolkitEnabled": false,
+        "devicePluginEnabled": false,
+        "gfdEnabled": true,
+        "dcgmExporterEnabled": true,
+        "gdsEnabled": true
+      }
+    }
+  }
+}
+```
+
+## Prometheus Integration
+
+If the [Monitoring](monitoring.md) component is installed **before** the GPU Operator, DCGM metrics are automatically scraped by Prometheus:
+
+1. GPU Operator detects `ServiceMonitor` CRD
+2. Creates `ServiceMonitor` for DCGM Exporter
+3. Prometheus auto-discovers and scrapes GPU metrics
+4. Grafana DCGM Dashboard displays GPU utilization, power, temperature
+
+## Troubleshooting
+
+### No GPU resources detected
+
+```bash
+# Check if GPUs are visible on the node
+kubectl debug node/<node-name> -it --image=ubuntu
+nvidia-smi
+
+# Check GPU Operator logs
+kubectl logs -n gpu-operator -l app=gpu-operator
+```
+
+### DCGM Exporter not running
+
+```bash
+# Check ServiceMonitor exists
+kubectl get servicemonitor -n gpu-operator
+
+# Check DCGM Exporter pod
+kubectl get pods -n gpu-operator -l app=dcgm-exporter
+kubectl logs -n gpu-operator -l app=dcgm-exporter
+```
+
+## Learn More
+
+- [NVIDIA GPU Operator Documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/)
+- [DCGM Exporter Metrics](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html#field-identifiers)
+- [CDI Specification](https://github.com/cncf-tags/container-device-interface/blob/main/SPEC.md)

--- a/docs/components/nvidia-platform/index.md
+++ b/docs/components/nvidia-platform/index.md
@@ -1,0 +1,136 @@
+# NVIDIA Dynamo Platform
+
+Deploy and serve LLM models with NVIDIA Dynamo on Kubernetes (on-premises) and Amazon EKS. The NVIDIA Platform provides a comprehensive suite of components for GPU-accelerated LLM inference with enterprise-grade monitoring, benchmarking, and auto-configuration.
+
+## Architecture
+
+```
+                    +-----------------------+
+                    |      CLI              |
+                    |  ./cli nvidia-platform |
+                    +----------+------------+
+                               |
+    +--------+--------+--------+--------+--------+
+    |        |        |        |        |        |
+  GPU Op   Monitor   Dynamo   Dynamo   Benchmark  AIConfig
+  DCGM     Prom,     Platform  vLLM    AIPerf,    Quick Est,
+           Grafana   etcd,     agg/     Pushgateway SLA Deploy
+                    Operator   disagg   Pareto
+```
+
+## Components
+
+| Component | Description | CLI Command |
+|-----------|-------------|-------------|
+| [GPU Operator](gpu-operator.md) | NVIDIA GPU resource management | `./cli nvidia-platform gpu-operator install` |
+| [Monitoring](monitoring.md) | Prometheus + Grafana + Dynamo/DCGM/KVBM/Benchmark dashboards | `./cli nvidia-platform monitoring install` |
+| [Dynamo Platform](dynamo-platform.md) | CRDs, Operator, etcd, NATS, Grove, KAI Scheduler | `./cli nvidia-platform dynamo-platform install` |
+| [Dynamo vLLM Serving](dynamo-vllm.md) | vLLM model deployment (agg/disagg, KV Router, KVBM) | `./cli nvidia-platform dynamo-vllm install` |
+| [AIPerf Benchmark](benchmark.md) | Concurrency sweep, multi-turn, seq distribution, prefix cache | `./cli nvidia-platform benchmark install` |
+| [AIConfigurator](aiconfigurator.md) | TP/PP recommendation (Quick Estimate) + SLA-driven profile + plan + deploy | `./cli nvidia-platform aiconfigurator install` |
+
+## Installation Order
+
+```bash
+# === Standard Path ===
+# 0. (K8s only) Install Ingress controller if not present
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx --force-update
+helm upgrade --install ingress-nginx ingress-nginx/ingress-nginx \
+  --namespace ingress-nginx --create-namespace --set controller.service.type=NodePort --wait
+
+# 1. Monitoring (Prometheus + Grafana) — install first so GPU Operator
+#    auto-detects ServiceMonitor CRDs and enables DCGM metrics scraping.
+./cli nvidia-platform monitoring install
+
+# 2. GPU Operator (detects Prometheus → creates DCGM ServiceMonitor)
+./cli nvidia-platform gpu-operator install
+
+# 3. Dynamo Platform (auto-detects Prometheus and sets prometheusEndpoint)
+./cli nvidia-platform dynamo-platform install
+
+# 4. Deploy a model
+./cli nvidia-platform dynamo-vllm install
+```
+
+## Platform Modes
+
+The NVIDIA Platform supports two deployment modes, configured via `PLATFORM` in `.env`:
+
+### K8s Mode (On-premises)
+
+**Environment**: `PLATFORM=k8s`
+
+Designed for bare-metal Kubernetes clusters with pre-installed NVIDIA drivers and Container Toolkit.
+
+**Prerequisites (user must prepare)**:
+- Kubernetes v1.33+
+- NVIDIA Driver 580+
+- NVIDIA Container Toolkit with CDI configured
+- Fabric Manager (for H100 SXM / NVSwitch GPUs)
+- StorageClass with ReadWriteMany access (e.g., NFS, CephFS)
+
+**Auto-installed by CLI**:
+- `local-path` StorageClass (if not found)
+- `ingress-nginx` (prompted if not found)
+- Prometheus endpoint auto-configuration
+
+### EKS Mode (Amazon Web Services)
+
+**Environment**: `PLATFORM=eks`
+
+Optimized for Amazon EKS with GPU node groups (g6e, p5, p4d, etc.).
+
+**Prerequisites (user must prepare)**:
+- EKS Cluster v1.33+
+- GPU node groups with EKS GPU AMI
+- HuggingFace token for gated model access
+
+**Auto-installed by CLI**:
+- EFS CSI Driver (via EKS addon)
+- EFS StorageClass
+- ALB Ingress annotations
+- Prometheus endpoint auto-configuration
+
+## Key Features
+
+### Deployment Modes
+- **Aggregated**: Single worker handles prefill + decode
+- **Disaggregated**: Separate prefill and decode workers with NIXL KV transfer
+
+### Parallelism Options
+- **Tensor Parallel (TP)**: Split model across GPUs
+- **Pipeline Parallel (PP)**: Split layers across GPUs
+- **Expert Parallel (EP)**: MoE expert distribution
+- **Replicas**: Pod-level scaling with Dynamo Frontend routing
+
+### Advanced Features
+- **KV Cache Routing**: Routes requests to workers with cached KV blocks
+- **KV Cache Offloading (KVBM)**: GPU → CPU → Disk cache hierarchy
+- **Model Download**: Pre-download to PVC with auto-detection
+- **Structured Logging**: Auto-enable if monitoring installed
+
+## Quick Test
+
+```bash
+# Port-forward the frontend service
+kubectl port-forward svc/<deployment>-frontend 8000:8000 -n dynamo-system --address 0.0.0.0 &
+
+# Auto-detect model name
+export MODEL=$(curl -s localhost:8000/v1/models | python3 -c "import sys,json; d=json.load(sys.stdin)['data']; print(d[0]['id'] if d else 'NONE')")
+
+# Chat completion
+curl localhost:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"$MODEL\",
+    \"messages\": [{\"role\": \"user\", \"content\": \"Hello! Who are you?\"}],
+    \"max_tokens\": 100,
+    \"stream\": false
+  }"
+```
+
+## Learn More
+
+- [NVIDIA Dynamo Platform Documentation](https://docs.nvidia.com/dynamo/)
+- [vLLM Documentation](https://docs.vllm.ai)
+- [GPU Operator Documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/)

--- a/docs/components/nvidia-platform/monitoring.md
+++ b/docs/components/nvidia-platform/monitoring.md
@@ -1,0 +1,190 @@
+# Monitoring (Prometheus + Grafana)
+
+Comprehensive monitoring stack with Prometheus, Grafana, and pre-configured dashboards for NVIDIA Dynamo Platform, DCGM GPU metrics, KV cache benchmarks, and LLM performance analysis.
+
+| | |
+|---|---|
+| **Category** | nvidia-platform |
+| **Official Docs** | [kube-prometheus-stack](https://github.com/prometheus-operator/kube-prometheus) |
+| **CLI Install** | `./cli nvidia-platform monitoring install` |
+| **CLI Uninstall** | `./cli nvidia-platform monitoring uninstall` |
+| **Namespace** | `monitoring` |
+
+## Overview
+
+The monitoring component deploys **kube-prometheus-stack** (Prometheus + Grafana) with specialized dashboards for:
+- Dynamo Frontend and Worker metrics
+- DCGM GPU utilization, power, temperature
+- KV cache usage and offloading (KVBM)
+- Benchmark Pareto comparison (TPS/GPU, TTFT, ITL)
+
+When installed before Dynamo Platform, the `prometheusEndpoint` is automatically detected and configured.
+
+## Installation
+
+```bash
+./cli nvidia-platform monitoring install
+```
+
+### Auto-Configuration
+
+No interactive prompts required. All settings are configured from `config.json`:
+
+| Setting | Default | Configured via |
+|---------|---------|---------------|
+| Grafana password | `admin` | `config.json` → `grafanaAdminPassword` |
+| Retention | `7d` | `config.json` → `retention` |
+| Alertmanager | `false` | `config.json` → `alertmanagerEnabled` |
+| Ingress | Auto-detect | Enabled if Ingress controller exists |
+| ALB annotations (EKS) | Auto-added | When `PLATFORM=eks` and Ingress detected |
+
+## Verification
+
+```bash
+# Check monitoring pods
+kubectl get pods -n monitoring
+
+# Check services
+kubectl get svc -n monitoring
+
+# Check Ingress (if enabled)
+kubectl get ingress -n monitoring
+```
+
+## Access
+
+### With Ingress (Recommended)
+
+If an Ingress controller is detected during installation, Grafana and Prometheus are accessible via HTTP path routing:
+
+**K8s Mode (on-premises)**:
+```bash
+# Find the NodePort
+kubectl get svc -n ingress-nginx
+
+# Access URLs
+http://<node-ip>:<node-port>/grafana
+http://<node-ip>:<node-port>/prometheus
+```
+
+**EKS Mode (ALB)**:
+```bash
+# Find the ALB address
+kubectl get ingress -n monitoring
+
+# Access URLs
+http://<alb-url>/grafana
+http://<alb-url>/prometheus
+```
+
+**Remote Access (SSH Tunnel)**:
+```bash
+# From your local machine
+ssh -N -L <local-port>:<node-ip>:<node-port> <user>@<remote-host>
+
+# Open in browser
+http://localhost:<local-port>/grafana
+http://localhost:<local-port>/prometheus
+```
+
+### Without Ingress (Port-Forward Fallback)
+
+```bash
+# Grafana
+kubectl port-forward svc/prometheus-grafana 3000:80 -n monitoring --address 0.0.0.0 &
+
+# Prometheus
+kubectl port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090 -n monitoring --address 0.0.0.0 &
+```
+
+## Grafana Login
+
+| Field | Value |
+|-------|-------|
+| User | `admin` |
+| Password | Configured during install (default: `admin`) |
+
+To retrieve the current password:
+
+```bash
+kubectl get secret prometheus-grafana -n monitoring \
+  -o jsonpath="{.data.admin-password}" | base64 --decode; echo
+```
+
+## Dashboards
+
+The monitoring stack includes pre-configured dashboards for comprehensive observability:
+
+| Dashboard | Description | Source |
+|-----------|-------------|--------|
+| **Dynamo Dashboard** | Frontend/Worker metrics, request rates, latencies | `monitoring/dashboards/dynamo-dashboard.json` |
+| **DCGM GPU Monitoring** | GPU utilization, memory, temperature, power | `monitoring/dashboards/dcgm-metrics.json` |
+| **KVBM KV Cache** | KV cache usage, offloading metrics | `monitoring/dashboards/kvbm.json` |
+| **Benchmark Pareto** | Benchmark comparison (TPS/GPU, TTFT, ITL vs concurrency) | `monitoring/dashboards/benchmark-dashboard.json` |
+
+Dashboards are auto-loaded via Grafana sidecar (ConfigMaps with `grafana_dashboard: "1"` label).
+
+### Benchmark Pareto Dashboard
+
+The Benchmark dashboard provides interactive comparison of LLM serving configurations:
+
+- **TPS/GPU vs Concurrency**: Throughput per GPU at different load levels
+- **TPS/User vs Concurrency**: Per-user throughput
+- **TTFT P50/P99 vs Concurrency**: Time to First Token latency
+- **ITL P50 vs Concurrency**: Inter-Token Latency
+- **GPU Efficiency**: TPS/GPU vs TPS/User scatter plot (top-right = optimal)
+
+Use the **Benchmark** dropdown to select and compare multiple benchmark runs.
+
+## Configuration
+
+Edit `config.json` to customize monitoring settings:
+
+```json
+{
+  "platform": {
+    "monitoring": {
+      "grafanaAdminPassword": "admin",
+      "retention": "7d",
+      "enablePersistentStorage": false,
+      "prometheusStorageSize": "50Gi",
+      "alertmanagerEnabled": false
+    }
+  }
+}
+```
+
+## Prometheus Pushgateway
+
+Pushgateway is automatically installed for collecting benchmark metrics. After each [AIPerf Benchmark](benchmark.md) run, metrics are pushed to Pushgateway and scraped by Prometheus.
+
+### Managing Benchmark Data
+
+To reset benchmark metrics in Grafana:
+
+```bash
+# Delete all Pushgateway data
+kubectl port-forward svc/pushgateway-prometheus-pushgateway 19091:9091 -n monitoring &
+sleep 2
+curl -s http://localhost:19091/metrics | grep -oP 'job="[^"]*"' | sort -u | sed 's/job="//;s/"//' | while read job; do
+  curl -X DELETE "http://localhost:19091/metrics/job/$job"
+done
+pkill -f "port-forward.*pushgateway"
+```
+
+## Integration with Dynamo Platform
+
+When monitoring is installed **before** Dynamo Platform:
+
+1. Dynamo Platform installer detects Prometheus endpoint
+2. Sets `prometheusEndpoint` in Helm values
+3. Dynamo Operator auto-creates PodMonitors for Frontend/Workers
+4. Worker metrics endpoint (`DYN_SYSTEM_PORT=9090`) auto-configured
+5. GPU metrics from DCGM Exporter auto-scraped via ServiceMonitor
+
+## Learn More
+
+- [Prometheus Documentation](https://prometheus.io/docs/)
+- [Grafana Documentation](https://grafana.com/docs/)
+- [kube-prometheus-stack](https://github.com/prometheus-operator/kube-prometheus)
+- [DCGM Exporter Metrics](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/feature-overview.html)

--- a/docs/components/observability/langfuse.md
+++ b/docs/components/observability/langfuse.md
@@ -1,0 +1,157 @@
+# Langfuse
+
+Open-source LLM observability platform for tracing, evaluating, and monitoring AI applications. Provides detailed visibility into LLM calls, token usage, latency, and costs.
+
+| | |
+|---|---|
+| **Category** | observability |
+| **Official Docs** | [Langfuse Documentation](https://langfuse.com/docs) |
+| **CLI Install** | `./cli o11y langfuse install` |
+| **CLI Uninstall** | `./cli o11y langfuse uninstall` |
+| **Namespace** | `langfuse` |
+
+## Overview
+
+Langfuse is the default observability backend for the starter kit:
+- **LLM Tracing**: Trace every LLM call with input/output, tokens, latency
+- **Cost Tracking**: Monitor spend per model, user, or feature
+- **Evaluations**: Score traces with manual or automated evaluations
+- **Prompt Management**: Version and manage prompts
+- **Datasets**: Create test datasets for evaluation
+- **Dashboards**: Built-in analytics and monitoring
+- **S3 Storage**: Uses Terraform-provisioned S3 bucket for blob storage
+
+## Installation
+
+### Prerequisites
+
+Configure in `.env`:
+
+```bash
+LANGFUSE_USERNAME=admin
+LANGFUSE_PASSWORD=your-password
+LANGFUSE_PUBLIC_KEY=pk-lf-xxxxxxxx
+LANGFUSE_SECRET_KEY=sk-lf-xxxxxxxx
+```
+
+### Install
+
+```bash
+./cli o11y langfuse install
+```
+
+The installer:
+1. Provisions an S3 bucket via Terraform for blob storage
+2. Adds the Langfuse Helm chart repository
+3. Renders Helm values with credentials and bucket configuration
+4. Deploys Langfuse to the `langfuse` namespace
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n langfuse
+
+# Check service
+kubectl get svc -n langfuse
+
+# Port-forward for UI access
+kubectl port-forward svc/langfuse-web 3000:3000 -n langfuse --address 0.0.0.0 &
+
+# Access Langfuse UI
+open http://localhost:3000
+```
+
+Log in with `LANGFUSE_USERNAME` and `LANGFUSE_PASSWORD`.
+
+## Integration
+
+### LiteLLM
+
+[LiteLLM](../ai-gateway/litellm.md) automatically sends traces to Langfuse when installed. Traces include:
+- Request/response pairs
+- Token usage per request
+- Latency breakdown
+- Model routing decisions
+
+### OpenClaw
+
+[OpenClaw](../ai-agent/openclaw.md) sends agent execution traces to Langfuse when `LANGFUSE_PUBLIC_KEY` and `LANGFUSE_SECRET_KEY` are configured.
+
+### Custom Applications
+
+```python
+from langfuse import Langfuse
+
+langfuse = Langfuse(
+    public_key="pk-lf-xxx",
+    secret_key="sk-lf-xxx",
+    host="http://langfuse-web.langfuse:3000"
+)
+
+trace = langfuse.trace(name="my-app")
+generation = trace.generation(
+    name="chat",
+    model="qwen3-30b-instruct-fp8",
+    input=[{"role": "user", "content": "Hello"}],
+    output="Hi there!"
+)
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `LANGFUSE_USERNAME` | Admin username |
+| `LANGFUSE_PASSWORD` | Admin password |
+| `LANGFUSE_PUBLIC_KEY` | API public key for SDK integrations |
+| `LANGFUSE_SECRET_KEY` | API secret key for SDK integrations |
+| `DOMAIN` | Domain for ingress (optional) |
+
+### Infrastructure
+
+Langfuse uses Terraform to provision:
+- S3 bucket for blob storage (traces, datasets)
+- IAM roles via IRSA for S3 access
+
+## Troubleshooting
+
+### UI not loading
+
+```bash
+# Check web pod status
+kubectl get pods -n langfuse -l app=web
+
+# Check logs
+kubectl logs -n langfuse -l app=web
+```
+
+### Traces not appearing
+
+```bash
+# Check LiteLLM integration
+kubectl logs -n litellm -l app=litellm | grep langfuse
+
+# Verify Langfuse credentials
+echo $LANGFUSE_PUBLIC_KEY
+echo $LANGFUSE_SECRET_KEY
+```
+
+### Database issues
+
+```bash
+# Check database pod
+kubectl get pods -n langfuse -l app=postgresql
+
+# Check database logs
+kubectl logs -n langfuse -l app=postgresql
+```
+
+## Learn More
+
+- [Langfuse Documentation](https://langfuse.com/docs)
+- [Langfuse GitHub](https://github.com/langfuse/langfuse)
+- [Langfuse Python SDK](https://langfuse.com/docs/sdk/python)
+- [LiteLLM Integration](https://langfuse.com/docs/integrations/litellm)

--- a/docs/components/observability/mlflow.md
+++ b/docs/components/observability/mlflow.md
@@ -1,0 +1,132 @@
+# MLflow
+
+Open-source platform for managing the end-to-end machine learning lifecycle, including experiment tracking, model registry, and deployment. Provides a centralized tracking server for logging metrics, parameters, and artifacts.
+
+| | |
+|---|---|
+| **Category** | observability |
+| **Official Docs** | [MLflow Documentation](https://mlflow.org/docs/latest) |
+| **CLI Install** | `./cli o11y mlflow install` |
+| **CLI Uninstall** | `./cli o11y mlflow uninstall` |
+| **Namespace** | `mlflow` |
+
+## Overview
+
+MLflow provides comprehensive ML lifecycle management:
+- **Experiment Tracking**: Log parameters, metrics, and artifacts
+- **Model Registry**: Version and stage ML models
+- **Model Serving**: Deploy models as REST endpoints
+- **S3 Artifact Storage**: Uses Terraform-provisioned S3 bucket
+- **Web UI**: Visual experiment comparison and analysis
+
+## Installation
+
+### Prerequisites
+
+Configure in `.env`:
+
+```bash
+MLFLOW_USERNAME=admin
+MLFLOW_PASSWORD=your-password
+```
+
+### Install
+
+```bash
+./cli o11y mlflow install
+```
+
+The installer:
+1. Provisions an S3 bucket via Terraform for artifact storage
+2. Adds the community Helm chart repository
+3. Renders Helm values with credentials and bucket configuration
+4. Deploys MLflow to the `mlflow` namespace
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n mlflow
+
+# Check service
+kubectl get svc -n mlflow
+
+# Port-forward for UI access
+kubectl port-forward svc/mlflow 5000:5000 -n mlflow --address 0.0.0.0 &
+
+# Access MLflow UI
+open http://localhost:5000
+```
+
+Log in with `MLFLOW_USERNAME` and `MLFLOW_PASSWORD`.
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `MLFLOW_USERNAME` | Admin username |
+| `MLFLOW_PASSWORD` | Admin password |
+| `DOMAIN` | Domain for ingress (optional) |
+
+### Infrastructure
+
+MLflow uses Terraform to provision:
+- S3 bucket for artifact storage (models, datasets, logs)
+- IAM roles via IRSA for S3 access
+
+## Usage
+
+### Python SDK
+
+```python
+import mlflow
+
+mlflow.set_tracking_uri("http://mlflow.mlflow:5000")
+mlflow.set_experiment("my-experiment")
+
+with mlflow.start_run():
+    mlflow.log_param("model", "qwen3-30b-instruct-fp8")
+    mlflow.log_metric("accuracy", 0.95)
+    mlflow.log_artifact("output.json")
+```
+
+### Model Registry
+
+```python
+# Register a model
+mlflow.register_model("runs:/<run-id>/model", "my-model")
+
+# Load a registered model
+model = mlflow.pyfunc.load_model("models:/my-model/Production")
+```
+
+## Troubleshooting
+
+### UI not loading
+
+```bash
+# Check pod status
+kubectl get pods -n mlflow
+
+# Check logs
+kubectl logs -n mlflow -l app=mlflow
+```
+
+### Artifact upload fails
+
+```bash
+# Check S3 bucket access
+kubectl exec -it -n mlflow <mlflow-pod> -- aws s3 ls s3://<bucket-name>/
+
+# Check IRSA configuration
+kubectl describe sa -n mlflow mlflow
+```
+
+## Learn More
+
+- [MLflow Documentation](https://mlflow.org/docs/latest)
+- [MLflow GitHub](https://github.com/mlflow/mlflow)
+- [MLflow Tracking](https://mlflow.org/docs/latest/tracking.html)
+- [MLflow Model Registry](https://mlflow.org/docs/latest/model-registry.html)

--- a/docs/components/observability/phoenix.md
+++ b/docs/components/observability/phoenix.md
@@ -1,0 +1,124 @@
+# Phoenix
+
+Arize Phoenix is an open-source AI observability platform for evaluating, troubleshooting, and fine-tuning LLM applications. Provides real-time tracing, embedding visualization, and evaluation tools.
+
+| | |
+|---|---|
+| **Category** | observability |
+| **Official Docs** | [Phoenix Documentation](https://docs.arize.com/phoenix) |
+| **CLI Install** | `./cli o11y phoenix install` |
+| **CLI Uninstall** | `./cli o11y phoenix uninstall` |
+| **Namespace** | `phoenix` |
+
+## Overview
+
+Phoenix provides AI-native observability:
+- **LLM Tracing**: OpenTelemetry-based tracing for LLM calls
+- **Embedding Analysis**: Visualize and analyze embedding drift
+- **Evaluations**: LLM-as-judge and custom evaluation metrics
+- **Retrieval Analysis**: Debug RAG pipeline retrieval quality
+- **Datasets**: Create and manage evaluation datasets
+- **Experiments**: Run and compare prompt experiments
+
+## Installation
+
+```bash
+./cli o11y phoenix install
+```
+
+The installer:
+1. Renders Helm values with domain configuration
+2. Deploys Phoenix using the official OCI Helm chart
+3. Creates the `phoenix` namespace
+
+No additional environment variables are required.
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n phoenix
+
+# Check service
+kubectl get svc -n phoenix
+
+# Port-forward for UI access
+kubectl port-forward svc/phoenix 6006:6006 -n phoenix --address 0.0.0.0 &
+
+# Access Phoenix UI
+open http://localhost:6006
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `DOMAIN` | Domain for ingress (optional) |
+
+## Usage
+
+### OpenTelemetry Integration
+
+Phoenix supports OpenTelemetry-based instrumentation:
+
+```python
+from phoenix.otel import register
+
+tracer_provider = register(
+    endpoint="http://phoenix.phoenix:6006/v1/traces"
+)
+```
+
+### LLM Tracing
+
+```python
+from openinference.instrumentation.openai import OpenAIInstrumentor
+
+OpenAIInstrumentor().instrument(tracer_provider=tracer_provider)
+
+# All OpenAI calls are now traced
+from openai import OpenAI
+client = OpenAI(base_url="http://litellm.litellm:4000/v1", api_key="sk-1234")
+response = client.chat.completions.create(
+    model="vllm/qwen3-30b-instruct-fp8",
+    messages=[{"role": "user", "content": "Hello!"}]
+)
+```
+
+### Embedding Visualization
+
+```python
+import phoenix as px
+
+px.launch_app()
+# Upload embeddings for visualization and drift detection
+```
+
+## Troubleshooting
+
+### UI not loading
+
+```bash
+# Check pod status
+kubectl get pods -n phoenix
+
+# Check logs
+kubectl logs -n phoenix -l app=phoenix
+```
+
+### Traces not appearing
+
+```bash
+# Verify OTLP endpoint is reachable
+kubectl exec -it -n <app-namespace> <app-pod> -- \
+  curl http://phoenix.phoenix:6006/v1/traces
+```
+
+## Learn More
+
+- [Phoenix Documentation](https://docs.arize.com/phoenix)
+- [Phoenix GitHub](https://github.com/Arize-ai/phoenix)
+- [OpenInference](https://github.com/Arize-ai/openinference)
+- [Phoenix Helm Chart](https://hub.docker.com/r/arizephoenix/phoenix-helm)

--- a/docs/components/vector-database/chroma.md
+++ b/docs/components/vector-database/chroma.md
@@ -1,0 +1,135 @@
+# Chroma
+
+Open-source AI-native embedding database designed for simplicity. Provides an easy-to-use API for storing and querying embeddings with automatic embedding generation support.
+
+| | |
+|---|---|
+| **Category** | vector-database |
+| **Official Docs** | [Chroma Documentation](https://docs.trychroma.com) |
+| **CLI Install** | `./cli vector-database chroma install` |
+| **CLI Uninstall** | `./cli vector-database chroma uninstall` |
+| **Namespace** | `chroma` |
+
+## Overview
+
+Chroma is designed for developer productivity:
+- **Simple API**: Minimal boilerplate for storing and querying embeddings
+- **Auto Embeddings**: Built-in embedding function support
+- **Metadata Filtering**: Filter results by document metadata
+- **Multi-Modal**: Support for text, images, and more
+- **Persistent Storage**: Durable storage with automatic persistence
+
+## Installation
+
+```bash
+./cli vector-database chroma install
+```
+
+The installer:
+1. Adds the Chroma Helm chart repository
+2. Renders Helm values
+3. Deploys ChromaDB via Helm to the `chroma` namespace
+
+No additional environment variables are required.
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n chroma
+
+# Check service
+kubectl get svc -n chroma
+
+# Port-forward for local access
+kubectl port-forward svc/chroma-chromadb 8000:8000 -n chroma --address 0.0.0.0 &
+
+# Check API
+curl http://localhost:8000/api/v1/heartbeat
+
+# List collections
+curl http://localhost:8000/api/v1/collections
+```
+
+## Usage
+
+### Python Client
+
+```python
+import chromadb
+
+client = chromadb.HttpClient(host="chroma-chromadb.chroma", port=8000)
+
+# Create collection
+collection = client.create_collection("my-collection")
+
+# Add documents (auto-generates embeddings)
+collection.add(
+    documents=["Hello world", "How are you?"],
+    ids=["doc1", "doc2"],
+    metadatas=[{"source": "greeting"}, {"source": "greeting"}]
+)
+
+# Query
+results = collection.query(
+    query_texts=["Hi there"],
+    n_results=2
+)
+```
+
+### With Custom Embeddings (TEI)
+
+```python
+import chromadb
+import requests
+
+def get_embeddings(texts):
+    response = requests.post(
+        "http://tei.tei:8080/v1/embeddings",
+        json={"model": "qwen3-embedding-06b-bf16-cpu", "input": texts}
+    )
+    return [d["embedding"] for d in response.json()["data"]]
+
+client = chromadb.HttpClient(host="chroma-chromadb.chroma", port=8000)
+collection = client.create_collection("my-collection")
+
+embeddings = get_embeddings(["Hello world", "How are you?"])
+collection.add(
+    embeddings=embeddings,
+    documents=["Hello world", "How are you?"],
+    ids=["doc1", "doc2"]
+)
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+# Check pod events
+kubectl describe pod -n chroma -l app=chromadb
+
+# Check logs
+kubectl logs -n chroma -l app=chromadb
+
+# Check PVC
+kubectl get pvc -n chroma
+```
+
+### Connection refused
+
+```bash
+# Verify service exists
+kubectl get svc -n chroma
+
+# Test connectivity
+kubectl exec -it -n <app-namespace> <app-pod> -- \
+  curl http://chroma-chromadb.chroma:8000/api/v1/heartbeat
+```
+
+## Learn More
+
+- [Chroma Documentation](https://docs.trychroma.com)
+- [Chroma GitHub](https://github.com/chroma-core/chroma)
+- [Chroma Python Client](https://docs.trychroma.com/reference/py-client)
+- [ChromaDB Helm Chart](https://github.com/amikos-tech/chromadb-chart)

--- a/docs/components/vector-database/milvus.md
+++ b/docs/components/vector-database/milvus.md
@@ -1,0 +1,160 @@
+# Milvus
+
+Cloud-native vector database built for scalable similarity search. Supports billion-scale vector search with GPU acceleration, hybrid search, and multi-tenancy.
+
+| | |
+|---|---|
+| **Category** | vector-database |
+| **Official Docs** | [Milvus Documentation](https://milvus.io/docs) |
+| **CLI Install** | `./cli vector-database milvus install` |
+| **CLI Uninstall** | `./cli vector-database milvus uninstall` |
+| **Namespace** | `milvus` |
+
+## Overview
+
+Milvus is designed for large-scale vector workloads:
+- **Billion-Scale**: Handles billions of vectors with efficient indexing
+- **GPU Acceleration**: Optional GPU-based index building and search
+- **Hybrid Search**: Combine vector similarity with scalar filtering
+- **Multi-Index**: IVF_FLAT, IVF_SQ8, HNSW, ANNOY, and more
+- **S3 Storage**: Uses Terraform-provisioned S3 bucket for object storage
+- **Distributed Architecture**: Separate compute and storage layers
+
+## Installation
+
+### Prerequisites
+
+Configure in `.env`:
+
+```bash
+MILVUS_USERNAME=admin
+MILVUS_PASSWORD=your-password
+```
+
+### Install
+
+```bash
+./cli vector-database milvus install
+```
+
+The installer:
+1. Provisions an S3 bucket via Terraform for object storage
+2. Deploys Milvus via Helm chart with S3 backend
+3. Creates Nginx basic auth secret for ingress
+4. Configures ingress with domain (if set)
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n milvus
+
+# Check service
+kubectl get svc -n milvus
+
+# Check ingress
+kubectl get ingress -n milvus
+
+# Port-forward for local access
+kubectl port-forward svc/milvus 19530:19530 -n milvus --address 0.0.0.0 &
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `MILVUS_USERNAME` | Username for ingress basic auth |
+| `MILVUS_PASSWORD` | Password for ingress basic auth |
+| `DOMAIN` | Domain for ingress (optional) |
+
+### Infrastructure
+
+Milvus uses Terraform to provision:
+- S3 bucket for object storage (vector data, indexes)
+- IAM roles via IRSA for S3 access
+
+## Usage
+
+### Python Client
+
+```python
+from pymilvus import connections, Collection, FieldSchema, CollectionSchema, DataType
+
+# Connect
+connections.connect(host="milvus.milvus", port="19530")
+
+# Define schema
+fields = [
+    FieldSchema(name="id", dtype=DataType.INT64, is_primary=True, auto_id=True),
+    FieldSchema(name="embedding", dtype=DataType.FLOAT_VECTOR, dim=768),
+    FieldSchema(name="text", dtype=DataType.VARCHAR, max_length=1024),
+]
+schema = CollectionSchema(fields, description="My collection")
+
+# Create collection
+collection = Collection("my_collection", schema)
+
+# Insert data
+collection.insert([
+    [[0.1, 0.2, ...]],  # embeddings
+    ["Hello world"],      # text
+])
+
+# Create index
+collection.create_index("embedding", {
+    "index_type": "HNSW",
+    "metric_type": "COSINE",
+    "params": {"M": 16, "efConstruction": 256}
+})
+
+# Search
+collection.load()
+results = collection.search(
+    data=[[0.1, 0.2, ...]],
+    anns_field="embedding",
+    param={"metric_type": "COSINE", "params": {"ef": 64}},
+    limit=5,
+    output_fields=["text"]
+)
+```
+
+## Troubleshooting
+
+### Pods not starting
+
+```bash
+# Check all Milvus components
+kubectl get pods -n milvus
+
+# Milvus has multiple components: proxy, datanode, indexnode, querynode
+kubectl describe pod -n milvus -l app.kubernetes.io/name=milvus
+```
+
+### S3 access issues
+
+```bash
+# Check IRSA configuration
+kubectl describe sa -n milvus
+
+# Check S3 bucket exists
+aws s3 ls | grep milvus
+```
+
+### Ingress authentication issues
+
+```bash
+# Check auth secret
+kubectl get secret -n milvus
+
+# Regenerate auth
+htpasswd -nb <username> <password>
+```
+
+## Learn More
+
+- [Milvus Documentation](https://milvus.io/docs)
+- [Milvus GitHub](https://github.com/milvus-io/milvus)
+- [PyMilvus SDK](https://github.com/milvus-io/pymilvus)
+- [Milvus Helm Chart](https://github.com/milvus-io/milvus-helm)

--- a/docs/components/vector-database/qdrant.md
+++ b/docs/components/vector-database/qdrant.md
@@ -1,0 +1,195 @@
+# Qdrant
+
+High-performance vector similarity search engine built in Rust. Provides fast and scalable vector storage with rich filtering, payload indexing, and a gRPC/REST API.
+
+| | |
+|---|---|
+| **Category** | vector-database |
+| **Official Docs** | [Qdrant Documentation](https://qdrant.tech/documentation) |
+| **CLI Install** | `./cli vector-database qdrant install` |
+| **CLI Uninstall** | `./cli vector-database qdrant uninstall` |
+| **Namespace** | `qdrant` |
+
+## Overview
+
+Qdrant is the default vector database in the demo stack:
+- **High Performance**: Written in Rust for maximum throughput and low latency
+- **Rich Filtering**: Combine vector search with payload-based filters
+- **Scalar & Binary Quantization**: Reduce memory usage while maintaining accuracy
+- **Distributed Mode**: Horizontal scaling with sharding and replication
+- **Snapshot & Backup**: Point-in-time snapshots for data protection
+- **REST & gRPC APIs**: Full-featured APIs for all operations
+
+## Installation
+
+### Prerequisites
+
+Configure in `.env`:
+
+```bash
+QDRANT_USERNAME=admin
+QDRANT_PASSWORD=your-password
+```
+
+### Install
+
+```bash
+./cli vector-database qdrant install
+```
+
+The installer:
+1. Adds the Qdrant Helm chart repository
+2. Renders Helm values and deploys via Helm
+3. Creates Nginx basic auth secret for ingress
+4. Configures ingress with domain (if set)
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n qdrant
+
+# Check service
+kubectl get svc -n qdrant
+
+# Check ingress
+kubectl get ingress -n qdrant
+
+# Port-forward for local access
+kubectl port-forward svc/qdrant 6333:6333 -n qdrant --address 0.0.0.0 &
+
+# Check cluster info
+curl http://localhost:6333/cluster
+
+# List collections
+curl http://localhost:6333/collections
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `QDRANT_USERNAME` | Username for ingress basic auth |
+| `QDRANT_PASSWORD` | Password for ingress basic auth |
+| `DOMAIN` | Domain for ingress (e.g., `qdrant.example.com`) |
+
+## Usage
+
+### Create a Collection
+
+```bash
+curl -X PUT http://localhost:6333/collections/my-collection \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vectors": {
+      "size": 768,
+      "distance": "Cosine"
+    }
+  }'
+```
+
+### Insert Vectors
+
+```bash
+curl -X PUT http://localhost:6333/collections/my-collection/points \
+  -H "Content-Type: application/json" \
+  -d '{
+    "points": [
+      {
+        "id": 1,
+        "vector": [0.1, 0.2, ...],
+        "payload": {"text": "Hello world"}
+      }
+    ]
+  }'
+```
+
+### Search
+
+```bash
+curl -X POST http://localhost:6333/collections/my-collection/points/search \
+  -H "Content-Type: application/json" \
+  -d '{
+    "vector": [0.1, 0.2, ...],
+    "limit": 5,
+    "with_payload": true
+  }'
+```
+
+### Python Client
+
+```python
+from qdrant_client import QdrantClient
+
+client = QdrantClient(url="http://qdrant.qdrant:6333")
+
+# Create collection
+client.create_collection(
+    collection_name="my-collection",
+    vectors_config={"size": 768, "distance": "Cosine"}
+)
+
+# Search
+results = client.search(
+    collection_name="my-collection",
+    query_vector=[0.1, 0.2, ...],
+    limit=5
+)
+```
+
+## Integration with TEI
+
+Use [TEI](../embedding-model/tei.md) to generate embeddings and store them in Qdrant:
+
+```python
+import requests
+from qdrant_client import QdrantClient
+
+# Generate embedding
+response = requests.post(
+    "http://tei.tei:8080/v1/embeddings",
+    json={"model": "qwen3-embedding-06b-bf16-cpu", "input": "Hello world"}
+)
+embedding = response.json()["data"][0]["embedding"]
+
+# Store in Qdrant
+client = QdrantClient(url="http://qdrant.qdrant:6333")
+client.upsert(
+    collection_name="my-collection",
+    points=[{"id": 1, "vector": embedding, "payload": {"text": "Hello world"}}]
+)
+```
+
+## Troubleshooting
+
+### Pod not starting
+
+```bash
+# Check pod events
+kubectl describe pod -n qdrant -l app=qdrant
+
+# Check PVC
+kubectl get pvc -n qdrant
+
+# Check logs
+kubectl logs -n qdrant -l app=qdrant
+```
+
+### Ingress authentication issues
+
+```bash
+# Check auth secret exists
+kubectl get secret -n qdrant
+
+# Regenerate auth
+htpasswd -nb <username> <password>
+```
+
+## Learn More
+
+- [Qdrant Documentation](https://qdrant.tech/documentation)
+- [Qdrant GitHub](https://github.com/qdrant/qdrant)
+- [Qdrant Python Client](https://github.com/qdrant/qdrant-client)
+- [Qdrant Helm Chart](https://github.com/qdrant/qdrant-helm)

--- a/docs/components/workflow-automation/n8n.md
+++ b/docs/components/workflow-automation/n8n.md
@@ -1,0 +1,114 @@
+# n8n
+
+Open-source workflow automation platform with a visual editor. Build complex AI-powered workflows by connecting LLMs, APIs, databases, and services with a no-code/low-code interface.
+
+| | |
+|---|---|
+| **Category** | workflow-automation |
+| **Official Docs** | [n8n Documentation](https://docs.n8n.io) |
+| **CLI Install** | `./cli workflow-automation n8n install` |
+| **CLI Uninstall** | `./cli workflow-automation n8n uninstall` |
+| **Namespace** | `n8n` |
+
+## Overview
+
+n8n enables visual workflow automation:
+- **Visual Editor**: Drag-and-drop workflow builder
+- **400+ Integrations**: Connect to databases, APIs, SaaS tools
+- **AI Nodes**: Built-in LLM, chat, and AI agent nodes
+- **Code Nodes**: Write custom JavaScript/Python when needed
+- **Webhooks**: Trigger workflows from HTTP requests
+- **Scheduling**: Cron-based workflow execution
+- **Self-Hosted**: Full control over data and execution
+
+## Installation
+
+```bash
+./cli workflow-automation n8n install
+```
+
+The installer:
+1. Renders Helm values with domain configuration
+2. Deploys n8n via OCI Helm chart
+3. Creates the `n8n` namespace
+
+No additional environment variables are required (beyond optional `DOMAIN`).
+
+## Verification
+
+```bash
+# Check pods
+kubectl get pods -n n8n
+
+# Check service
+kubectl get svc -n n8n
+
+# Port-forward for local access
+kubectl port-forward svc/n8n 5678:5678 -n n8n --address 0.0.0.0 &
+
+# Access n8n UI
+open http://localhost:5678
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `DOMAIN` | Domain for ingress (optional) |
+
+## Usage
+
+### AI Workflows with LiteLLM
+
+Create AI-powered workflows by connecting n8n to [LiteLLM](../ai-gateway/litellm.md):
+
+1. Add an **HTTP Request** node or **OpenAI** node
+2. Set the base URL to `http://litellm.litellm:4000/v1`
+3. Configure the API key (LiteLLM master key)
+4. Select the model and configure parameters
+
+### Example: Chat Workflow
+
+1. **Webhook Trigger**: Receive incoming messages
+2. **OpenAI Chat**: Send to LLM via LiteLLM
+3. **HTTP Response**: Return the generated response
+
+### Example: RAG Workflow
+
+1. **Webhook Trigger**: Receive a question
+2. **Qdrant Search**: Find relevant documents
+3. **OpenAI Chat**: Generate answer with context
+4. **HTTP Response**: Return the answer
+
+## Troubleshooting
+
+### UI not loading
+
+```bash
+# Check pod status
+kubectl get pods -n n8n
+
+# Check logs
+kubectl logs -n n8n -l app=n8n
+```
+
+### Cannot connect to cluster services
+
+```bash
+# n8n runs inside the cluster, use internal DNS
+# LiteLLM: http://litellm.litellm:4000
+# Qdrant: http://qdrant.qdrant:6333
+# TEI: http://tei.tei:8080
+
+# Test from n8n pod
+kubectl exec -it -n n8n <n8n-pod> -- curl http://litellm.litellm:4000/health
+```
+
+## Learn More
+
+- [n8n Documentation](https://docs.n8n.io)
+- [n8n GitHub](https://github.com/n8n-io/n8n)
+- [n8n AI Nodes](https://docs.n8n.io/integrations/builtin/cluster-nodes/root-nodes/n8n-nodes-langchain.lmchatopenai/)
+- [n8n Workflow Templates](https://n8n.io/workflows/)

--- a/docs/examples/agno/calculator-agent.md
+++ b/docs/examples/agno/calculator-agent.md
@@ -1,0 +1,343 @@
+# Agno Calculator Agent
+
+An AI agent built with the Agno framework that performs arithmetic calculations using MCP tools. The agent features memory management, session persistence, and conversation history tracking, demonstrating advanced agentic capabilities.
+
+## What It Does
+
+The Agno Calculator Agent:
+
+- Accepts natural language calculation requests via HTTP API
+- Uses AI models (Claude, GPT, etc.) to understand requests
+- Executes calculations using MCP tools from the Calculator MCP Server
+- Maintains conversation history across sessions
+- Stores user memories using SQLite for context persistence
+- Integrates with Langfuse for observability via OpenLIT
+
+## Installation
+
+Install the Agno Calculator Agent:
+
+```bash
+./cli agno calculator-agent install
+```
+
+This will:
+
+1. Build a Docker image containing the Agno agent code
+2. Push the image to Amazon ECR
+3. Deploy the agent as a Kubernetes Deployment
+4. Create a Service at `http://calculator-agent.agno:8080`
+5. Register the agent as a pipe function in Open WebUI (if installed)
+
+## Verification
+
+Check the deployment status:
+
+```bash
+# Check pods
+kubectl get pods -n agno -l app=calculator-agent
+
+# Check service
+kubectl get svc -n agno calculator-agent
+
+# Check logs
+kubectl logs -n agno -l app=calculator-agent
+
+# Test agent endpoint
+kubectl port-forward -n agno svc/calculator-agent 8080:8080
+curl -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is 42 plus 58?"}'
+```
+
+## Key Files
+
+### agent.py
+
+The main Agno agent implementation with memory and session management:
+
+```python
+from agno.agent import Agent
+from agno.models.openai.like import OpenAILike
+from agno.tools.mcp import MCPTools
+from agno.memory import MemoryManager
+from agno.db.sqlite import SqliteDb
+from fastapi import FastAPI
+from fastapi.responses import PlainTextResponse
+
+# Configure model (LiteLLM or Bedrock)
+if os.environ.get("USE_BEDROCK", "").lower() == "true":
+    model = AwsBedrock(id=os.environ.get("BEDROCK_MODEL"))
+else:
+    model = OpenAILike(
+        base_url=os.environ.get("LITELLM_BASE_URL"),
+        api_key=os.environ.get("LITELLM_API_KEY"),
+        id=os.environ.get("LITELLM_MODEL_NAME"),
+    )
+
+# Connect to MCP tools
+mcp_tools = MCPTools(
+    url="http://calculator.mcp-server:8000/mcp",
+    transport="streamable-http"
+)
+
+# Configure memory and session persistence
+db_file = "tmp/agent.db"
+memory_manager = MemoryManager(
+    model=model,
+    db=SqliteDb(db_file=db_file, memory_table="user_memories"),
+)
+db = SqliteDb(db_file=db_file, session_table="agent_sessions")
+
+agent = Agent(
+    model=model,
+    system_message=system_prompt,
+    tools=[mcp_tools],
+    memory_manager=memory_manager,
+    enable_agentic_memory=True,
+    db=db,
+    add_history_to_context=True,
+    num_history_runs=3,
+)
+
+@app.post("/")
+async def prompt(request: PromptRequest):
+    user_id = "ava"
+    response = await agent.arun(
+        request.prompt, user_id=user_id, markdown=True, stream=False
+    )
+    return PlainTextResponse(response.content)
+```
+
+### openwebui_pipe_function.py
+
+Open WebUI integration for interactive chat:
+
+```python
+class Pipe:
+    def __init__(self):
+        self.type = "manifold"
+        self.id = "agno_calculator_agent"
+        self.name = "Agno: Calculator Agent"
+    
+    def pipe(self, body: dict) -> str:
+        # Forward request to agent service
+        response = requests.post(
+            "http://calculator-agent.agno:8080",
+            json={"prompt": user_message}
+        )
+        return response.text
+```
+
+### Dockerfile
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY agent.py .
+EXPOSE 8080
+CMD ["uvicorn", "agent:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+## How It Works
+
+1. **Request Reception**: The FastAPI server receives POST requests with calculation prompts
+2. **Session Management**: The agent loads conversation history for the user (user_id: "ava")
+3. **Memory Retrieval**: Relevant memories are retrieved from SQLite to provide context
+4. **Agent Reasoning**: The Agno Agent uses the model to understand the request and plan tool usage
+5. **MCP Tool Execution**: The agent calls calculator tools via MCP protocol
+6. **Memory Update**: New learnings are stored in the memory database
+7. **Session Persistence**: Conversation history is saved for future requests
+8. **Response**: Results are returned as plain text
+
+### Memory Management
+
+The agent features two types of persistence:
+
+**User Memories** (`user_memories` table):
+- Stores facts and context learned from conversations
+- Retrieved automatically for relevant queries
+- Helps the agent remember user preferences and past interactions
+
+**Session History** (`agent_sessions` table):
+- Stores recent conversation turns
+- Configurable via `num_history_runs` (default: 3)
+- Provides context for follow-up questions
+
+Example:
+```
+User: "What is 100 plus 50?"
+Agent: "150"
+
+User: "Now multiply that by 2"
+Agent: "300" (remembers previous result from session history)
+```
+
+## Configuration
+
+Configure the agent via environment variables in `.env.local` or `config.json`:
+
+```json
+{
+  "examples": {
+    "agno": {
+      "calculator-agent": {
+        "env": {
+          "USE_BEDROCK": "false",
+          "LITELLM_MODEL_NAME": "bedrock/claude-4.5-sonnet",
+          "LITELLM_BASE_URL": "http://litellm.litellm:4000",
+          "LITELLM_API_KEY": "${LITELLM_API_KEY}"
+        }
+      }
+    }
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `USE_BEDROCK` | Use Bedrock instead of LiteLLM | `false` |
+| `LITELLM_BASE_URL` | LiteLLM API endpoint | `http://litellm.litellm:4000` |
+| `LITELLM_API_KEY` | LiteLLM API key | From `.env` |
+| `LITELLM_MODEL_NAME` | Model to use | `bedrock/claude-4.5-sonnet` |
+| `BEDROCK_MODEL` | Bedrock model ID | `us.anthropic.claude-3-7-sonnet-20250219-v1:0` |
+| `LANGFUSE_HOST` | Langfuse endpoint (optional) | Auto-detected |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public key (optional) | From `.env` |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret key (optional) | From `.env` |
+
+## Open WebUI Integration
+
+The agent is automatically registered in Open WebUI during installation. No manual setup is needed.
+
+!!! note
+    If Open WebUI was not running during install, re-run `./cli agno calculator-agent install` to register the pipe function.
+
+### Using the Agent
+
+1. Open Open WebUI in your browser
+2. Start a new chat
+3. Select **Agno: Calculator Agent** from the model dropdown
+4. Have a multi-turn conversation:
+
+```
+You: What is 25 times 4?
+Agent: 25 multiplied by 4 equals 100.
+
+You: Now add 50 to that
+Agent: 100 plus 50 equals 150.
+
+You: Divide the result by 3
+Agent: 150 divided by 3 equals 50.
+```
+
+## Example Requests
+
+### Direct API
+
+```bash
+# Simple calculation
+curl -X POST http://calculator-agent.agno:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is 42 plus 58?"}'
+
+# Complex expression
+curl -X POST http://calculator-agent.agno:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Calculate (75 * 4) - 100"}'
+
+# Follow-up question (uses session history)
+curl -X POST http://calculator-agent.agno:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Now divide that by 2"}'
+```
+
+## Langfuse Observability
+
+If Langfuse is installed and configured, the agent automatically sends traces via OpenLIT:
+
+1. Open Langfuse UI
+2. Navigate to **Traces**
+3. Filter by user_id or session
+4. View detailed execution traces including:
+   - Model calls and responses
+   - MCP tool invocations
+   - Memory retrievals and updates
+   - Token usage
+   - Latency metrics
+   - Error events
+
+### OpenLIT Integration
+
+The agent uses OpenLIT to bridge OpenTelemetry traces to Langfuse:
+
+```python
+import openlit
+from langfuse import get_client
+
+langfuse = get_client()
+openlit.init(tracer=langfuse._otel_tracer, disable_batch=True)
+```
+
+This provides automatic instrumentation for:
+- LLM API calls
+- Tool executions
+- Memory operations
+- Session management
+
+## Memory Database
+
+The agent stores data in SQLite at `tmp/agent.db`:
+
+**Schema:**
+- `user_memories` - User-specific facts and preferences
+- `agent_sessions` - Conversation history by user_id
+
+**Persistence:**
+To persist memories across pod restarts, mount a PersistentVolume:
+
+```yaml
+volumeMounts:
+  - name: agent-data
+    mountPath: /app/tmp
+volumes:
+  - name: agent-data
+    persistentVolumeClaim:
+      claimName: agno-calculator-agent-pvc
+```
+
+## Uninstallation
+
+Remove the Calculator Agent:
+
+```bash
+./cli agno calculator-agent uninstall
+```
+
+This will delete the Deployment, Service, and Open WebUI pipe function.
+
+!!! warning
+    Memory database (`tmp/agent.db`) will be lost unless stored on a PersistentVolume.
+
+## Comparison: Agno vs Strands
+
+| Feature | Agno | Strands |
+|---------|------|---------|
+| Memory Management | ✅ Built-in with SQLite | ❌ Manual implementation required |
+| Session History | ✅ Automatic with configurable depth | ❌ Not included |
+| Streaming | ❌ Returns complete response | ✅ Real-time streaming |
+| MCP Tools | ✅ Native MCPTools | ✅ MCPClient |
+| Observability | ✅ OpenLIT + Langfuse | ✅ Direct OTEL integration |
+| Database | ✅ SqliteDb included | ❌ Bring your own |
+
+## References
+
+- [Agno Documentation](https://docs.agno.com)
+- [Agno GitHub Repository](https://github.com/agno-agi/agno)
+- [FastAPI Documentation](https://fastapi.tiangolo.com)
+- [Model Context Protocol](https://modelcontextprotocol.io)
+- [OpenLIT Documentation](https://docs.openlit.io)

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -1,0 +1,51 @@
+# Examples
+
+This section contains ready-to-deploy examples demonstrating various AI frameworks and tools on Amazon EKS. Each example provides practical implementations that you can use as a starting point for your own applications.
+
+## MCP Server
+
+Model Context Protocol (MCP) servers provide standardized interfaces for AI models to interact with external tools and data sources.
+
+- **[Calculator MCP Server](mcp-server/calculator.md)** - Basic arithmetic operations exposed via FastMCP protocol
+
+## AI Agent Frameworks
+
+Examples showcasing different AI agent frameworks for building conversational AI applications with tool usage capabilities.
+
+### Strands Agents
+
+- **[Calculator Agent](strands-agents/calculator-agent.md)** - Agent using Strands framework with MCP or Python tools for arithmetic operations
+
+### Agno
+
+- **[Calculator Agent](agno/calculator-agent.md)** - Agent using Agno framework with memory management and MCP tool integration
+
+### OpenClaw
+
+- **[Document Writer Agent](openclaw/doc-writer.md)** - Autonomous documentation agent that clones repos, analyzes code, and commits documentation
+- **[DevOps Agent](openclaw/devops-agent.md)** - Interactive cluster management assistant with kubectl, helm, and AWS CLI access
+
+## Quick Start
+
+All examples can be installed using the CLI:
+
+```bash
+./cli <category> <example> install
+
+# Examples:
+./cli mcp-server calculator install
+./cli strands-agents calculator-agent install
+./cli agno calculator-agent install
+./cli openclaw doc-writer install
+./cli openclaw devops-agent install
+```
+
+## Prerequisites
+
+Most examples require:
+
+- EKS cluster with configured kubectl access
+- LiteLLM AI gateway (`./cli ai-gateway litellm install`)
+- Open WebUI (`./cli gui-app openwebui install`) for interactive testing
+
+Check each example's documentation for specific requirements and configuration options.

--- a/docs/examples/mcp-server/calculator.md
+++ b/docs/examples/mcp-server/calculator.md
@@ -1,0 +1,226 @@
+# Calculator MCP Server
+
+A Model Context Protocol (MCP) server that exposes basic arithmetic operations as tools. Built with FastMCP 2.0, this server provides a standardized interface for AI models to perform calculations.
+
+## What It Does
+
+The Calculator MCP Server provides four arithmetic operations:
+
+- **add** - Add two numbers together
+- **subtract** - Subtract one number from another
+- **multiply** - Multiply two numbers together
+- **divide** - Divide one number by another (with zero-check)
+
+These tools can be consumed by any MCP-compatible AI agent or application.
+
+## Installation
+
+Install the Calculator MCP Server:
+
+```bash
+./cli mcp-server calculator install
+```
+
+This will:
+
+1. Build a Docker image from the Python source code
+2. Push the image to Amazon ECR
+3. Deploy the server as a Kubernetes Deployment
+4. Create a Service at `http://calculator.mcp-server:8000`
+
+## Verification
+
+Check the deployment status:
+
+```bash
+# Check pods
+kubectl get pods -n mcp-server -l app=calculator
+
+# Check service
+kubectl get svc -n mcp-server calculator
+
+# Check logs
+kubectl logs -n mcp-server -l app=calculator
+
+# Test MCP endpoint
+kubectl port-forward -n mcp-server svc/calculator 8000:8000
+curl http://localhost:8000/mcp
+```
+
+Expected response: MCP protocol metadata including available tools.
+
+## Key Files
+
+### server.py
+
+The main FastMCP server implementation:
+
+```python
+from fastmcp import FastMCP
+
+mcp = FastMCP("Calculator")
+
+@mcp.tool(description="Add two numbers together")
+def add(x: int, y: int) -> int:
+    """Add two numbers and return the result."""
+    return x + y
+
+@mcp.tool(description="Subtract one number from another")
+def subtract(x: int, y: int) -> int:
+    """Subtract y from x and return the result."""
+    return x - y
+
+@mcp.tool(description="Multiply two numbers together")
+def multiply(x: int, y: int) -> int:
+    """Multiply two numbers and return the result."""
+    return x * y
+
+@mcp.tool(description="Divide one number by another")
+def divide(x: float, y: float) -> float:
+    """Divide x by y and return the result."""
+    if y == 0:
+        raise ValueError("Cannot divide by zero")
+    return x / y
+
+if __name__ == "__main__":
+    mcp.run()
+```
+
+### Dockerfile
+
+Multi-stage build using Python 3.12:
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY __init__.py .
+COPY server.py .
+EXPOSE 8000
+CMD ["fastmcp", "run", "server.py", "--transport", "http", "--host", "0.0.0.0", "--port", "8000"]
+```
+
+### requirements.txt
+
+```
+fastmcp==3.2.0
+```
+
+## How It Works
+
+1. **FastMCP Framework**: The server uses the FastMCP framework, which provides decorators to expose Python functions as MCP tools
+2. **HTTP Transport**: The server runs with HTTP transport on port 8000, exposing the `/mcp` endpoint
+3. **Tool Registration**: Each `@mcp.tool()` decorated function is automatically registered as an MCP tool with its signature and documentation
+4. **Kubernetes Service**: The server is accessible cluster-wide via the Service DNS name `calculator.mcp-server`
+
+## Usage with AI Agents
+
+The Calculator MCP Server can be consumed by various AI agent frameworks:
+
+### Strands Agents
+
+```python
+from agno.tools.mcp import MCPTools
+
+mcp_tools = MCPTools(
+    url="http://calculator.mcp-server:8000/mcp",
+    transport="streamable-http"
+)
+agent = Agent(model=model, tools=[mcp_tools])
+```
+
+### Agno
+
+```python
+from agno.tools.mcp import MCPTools
+
+mcp_tools = MCPTools(
+    url="http://calculator.mcp-server:8000/mcp",
+    transport="streamable-http"
+)
+agent = Agent(model=model, tools=[mcp_tools])
+```
+
+### LiteLLM MCP Gateway
+
+```python
+# Configure LiteLLM to proxy MCP servers
+headers = {
+    "Authorization": f"Bearer {LITELLM_API_KEY}",
+    "x-litellm-api-key": f"Bearer {LITELLM_API_KEY}"
+}
+mcp_client = MCPClient(
+    lambda: streamablehttp_client(
+        f"{LITELLM_BASE_URL}/mcp", headers=headers
+    )
+)
+```
+
+## Configuration
+
+The server can be customized via environment variables in `config.json`:
+
+```json
+{
+  "examples": {
+    "mcp-server": {
+      "calculator": {
+        "replicas": 1,
+        "resources": {
+          "requests": {
+            "cpu": "100m",
+            "memory": "128Mi"
+          },
+          "limits": {
+            "cpu": "500m",
+            "memory": "256Mi"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Uninstallation
+
+Remove the Calculator MCP Server:
+
+```bash
+./cli mcp-server calculator uninstall
+```
+
+This will delete the Deployment and Service from the `mcp-server` namespace.
+
+## Extending the Server
+
+To add more tools, edit `examples/mcp-server/calculator/server.py`:
+
+```python
+@mcp.tool(description="Calculate power of a number")
+def power(base: float, exponent: float) -> float:
+    """Calculate base raised to the power of exponent."""
+    return base ** exponent
+
+@mcp.tool(description="Calculate square root")
+def sqrt(x: float) -> float:
+    """Calculate square root of a number."""
+    import math
+    if x < 0:
+        raise ValueError("Cannot calculate square root of negative number")
+    return math.sqrt(x)
+```
+
+Then rebuild and redeploy:
+
+```bash
+./cli mcp-server calculator install
+```
+
+## References
+
+- [FastMCP Documentation](https://gofastmcp.com)
+- [Model Context Protocol Specification](https://modelcontextprotocol.io)
+- [FastMCP GitHub Repository](https://github.com/jlowin/fastmcp)

--- a/docs/examples/openclaw/devops-agent.md
+++ b/docs/examples/openclaw/devops-agent.md
@@ -1,0 +1,401 @@
+# OpenClaw DevOps Agent
+
+An interactive AI assistant for Kubernetes cluster management and troubleshooting. The agent has kubectl, helm, and AWS CLI access with read-only RBAC permissions, making it a safe and powerful tool for cluster inspection, diagnostics, and recommendations.
+
+## What It Does
+
+The DevOps Agent:
+
+- Inspects cluster resources (pods, services, deployments, nodes)
+- Analyzes logs and events for troubleshooting
+- Queries Helm releases and their configurations
+- Checks AWS resources related to the cluster
+- Provides actionable recommendations
+- Explains configuration issues and best practices
+- Streams responses for interactive conversations
+
+## Installation
+
+### 1. Prerequisites
+
+Install required components:
+
+```bash
+./cli ai-agent openclaw install      # OpenClaw bridge server
+./cli ai-gateway litellm install     # LiteLLM for model access
+./cli gui-app openwebui install      # Open WebUI for interaction
+```
+
+### 2. Configure Environment Variables
+
+Add to `.env.local`:
+
+```bash
+# Required
+LITELLM_API_KEY=sk-1234567890abcdef
+
+# Optional: Observability
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+```
+
+### 3. Install Agent
+
+```bash
+./cli openclaw devops-agent install
+```
+
+This will:
+
+1. Deploy the agent as a Kubernetes Deployment
+2. Create ServiceAccount with read-only ClusterRole
+3. Create Service at `http://devops-agent.openclaw:8080`
+4. Automatically register the pipe function in Open WebUI
+
+## Verification
+
+Check the deployment:
+
+```bash
+# Check pods
+kubectl get pods -n openclaw -l app=devops-agent
+
+# Check service
+kubectl get svc -n openclaw devops-agent
+
+# Check RBAC
+kubectl get clusterrole devops-agent-reader
+kubectl get clusterrolebinding devops-agent-reader-binding
+
+# Check logs
+kubectl logs -n openclaw -l app=devops-agent
+
+# Test health endpoint
+kubectl port-forward -n openclaw svc/devops-agent 8080:8080
+curl http://localhost:8080/health
+```
+
+## How It Works
+
+### Agent Workflow
+
+```mermaid
+graph LR
+    A[User Query] --> B[Understand Intent]
+    B --> C[Execute kubectl/helm/aws]
+    C --> D[Analyze Output]
+    D --> E[Generate Recommendations]
+    E --> F[Stream Response]
+```
+
+1. **Parse Request**: Understands what information the user needs
+2. **Execute Commands**: Runs kubectl, helm, or AWS CLI commands
+3. **Analyze Results**: LLM processes command output
+4. **Generate Insights**: Provides explanations and recommendations
+5. **Stream Response**: Sends formatted response to user
+
+### Available Tools
+
+| Tool | Purpose | Example Commands |
+|------|---------|-----------------|
+| **kubectl** | Kubernetes resource management | `get pods`, `describe deployment`, `logs`, `top nodes`, `get events` |
+| **helm** | Helm release management | `list --all-namespaces`, `status`, `get values`, `history` |
+| **AWS CLI** | AWS resource queries | `eks list-clusters`, `ec2 describe-security-groups`, `rds describe-db-instances` |
+
+## Open WebUI Integration
+
+The pipe function is automatically registered during installation.
+
+!!! note
+    If Open WebUI was not running during install, re-run `./cli openclaw devops-agent install`.
+
+### Using the Agent
+
+1. Open Open WebUI
+2. Start a new chat
+3. Select **OpenClaw - DevOps Agent** from the model dropdown
+4. Ask questions about your cluster
+
+## Example Queries
+
+### Cluster Health
+
+```
+Check the overall health of my cluster - node status, pod failures, resource usage, recent events
+```
+
+### Pod Troubleshooting
+
+```
+Why is pod "my-app-xyz" in default namespace failing? Analyze status, events, logs, resource limits
+```
+
+### Resource Inspection
+
+```
+List all deployments in the production namespace and their replica counts
+
+Show all services of type LoadBalancer across all namespaces
+
+What pods are consuming the most CPU in kube-system?
+```
+
+### Helm Releases
+
+```
+List all Helm releases in the cluster and their status
+
+Show the values used for the "litellm" Helm release in the litellm namespace
+
+What version of vLLM is currently deployed?
+```
+
+### AWS Resources
+
+```
+List all EKS clusters in us-west-2 region
+
+Show security groups attached to my EKS cluster
+
+What IAM roles are associated with this cluster?
+```
+
+### Log Analysis
+
+```
+Analyze logs from "api-server" deployment in default namespace for errors
+
+Show last 100 lines of logs from all pods with label app=frontend
+
+Are there any crash loops in the cluster?
+```
+
+### Recommendations
+
+```
+Review resource requests/limits for "web-app" deployment and suggest optimizations
+
+Analyze ingress configuration for "my-service" and recommend improvements
+
+Check if any pods are running with security vulnerabilities
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `OPENCLAW_GATEWAY_TOKEN` | Authentication token | `openclaw-gateway-token` |
+| `LITELLM_BASE_URL` | LiteLLM API endpoint | `http://litellm.litellm:4000` |
+| `LITELLM_API_KEY` | LiteLLM API key | From `.env` |
+| `LITELLM_MODEL_NAME` | Model to use | `bedrock/claude-4.5-sonnet` |
+| `LANGFUSE_HOST` | Langfuse endpoint (optional) | Auto-detected |
+
+### config.json
+
+```json
+{
+  "examples": {
+    "openclaw": {
+      "devops-agent": {
+        "env": {
+          "LITELLM_MODEL_NAME": "bedrock/claude-4.5-sonnet",
+          "OPENCLAW_GATEWAY_TOKEN": "openclaw-gateway-token"
+        }
+      }
+    }
+  }
+}
+```
+
+## RBAC Permissions
+
+The DevOps Agent has read-only access to cluster resources:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: devops-agent-reader
+rules:
+- apiGroups: ["*"]
+  resources: ["*"]
+  verbs: ["get", "list", "watch"]
+```
+
+### What the Agent Can Do
+
+- ✅ List and describe all resources
+- ✅ View logs from pods
+- ✅ Check resource status and events
+- ✅ Query Helm releases
+- ✅ Run AWS CLI read operations
+
+### What the Agent Cannot Do
+
+- ❌ Create, update, or delete resources
+- ❌ Execute commands in pods (`kubectl exec`)
+- ❌ Modify configurations
+- ❌ Read Kubernetes Secrets (explicitly excluded)
+- ❌ Scale deployments
+- ❌ Apply manifests
+
+## Security Considerations
+
+!!! warning "Cluster-Wide Read Access"
+    The DevOps Agent uses a **ClusterRole** that grants read access (`get`, `list`, `watch`) to resources **across all namespaces**. Combined with `automountServiceAccountToken: true`, an LLM-driven agent with this access poses security risks:
+    
+    - **Prompt injection**: Malicious prompts could instruct the agent to read sensitive configmaps or environment variables
+    - **Data exfiltration**: Agent could be tricked into including sensitive data in responses
+    - **Lateral discovery**: Full cluster visibility reveals infrastructure details that should be compartmentalized
+    
+    **For production use, replace ClusterRole/ClusterRoleBinding with namespace-scoped Role/RoleBinding** to limit the blast radius.
+
+### Security Features
+
+- **Read-only access**: Agent cannot modify cluster resources
+- **No exec**: Agent cannot execute commands in pods
+- **No secrets**: Agent cannot read Kubernetes Secrets
+- **Audit logs**: All kubectl commands logged in Kubernetes audit logs
+- **RBAC enforced**: Permissions strictly limited by ClusterRole
+
+### Recommended Security Enhancements
+
+For production use:
+
+1. **Namespace-scoped access** (strongly recommended):
+   ```yaml
+   apiVersion: rbac.authorization.k8s.io/v1
+   kind: Role
+   metadata:
+     name: devops-agent-reader
+     namespace: production
+   rules:
+   - apiGroups: ["apps", ""]
+     resources: ["deployments", "pods", "services"]
+     verbs: ["get", "list", "watch"]
+   ```
+
+2. **Resource filtering**: Limit to specific resource types
+3. **Network policies**: Restrict agent network access
+4. **Pod security standards**: Apply restricted PSS
+5. **Audit logging**: Enable detailed Kubernetes audit logs
+6. **Review responses**: Periodically check for data exposure
+
+## Langfuse Observability
+
+If Langfuse is installed, view agent execution traces:
+
+1. Open Langfuse UI
+2. Navigate to **Traces**
+3. Filter by `devops-agent` tag
+4. View detailed metrics:
+   - Query submission time
+   - kubectl/helm/aws commands executed
+   - LLM API calls with prompts and responses
+   - Token usage and costs
+   - Response latency
+   - Error events
+
+## Cost Optimization
+
+- **Long-lived deployment**: Runs continuously for low-latency responses
+- **Resource limits**: Configured with minimal CPU/memory requests
+- **Spot instances**: Karpenter provisions Spot ARM64 nodes (up to 90% savings)
+- **Model selection**: Use smaller models for faster, cheaper responses
+
+Estimated cost: ~$0.01-0.02 per hour (excluding LLM API costs)
+
+## Troubleshooting
+
+### Agent returns "permission denied"
+
+**Problem**: Agent lacks RBAC permissions
+
+**Solution**: Verify ClusterRoleBinding:
+```bash
+kubectl get clusterrolebinding devops-agent-reader-binding -o yaml
+```
+
+### Agent cannot access AWS resources
+
+**Problem**: Pod lacks AWS IAM permissions
+
+**Solution**: Ensure EKS node IAM role has necessary permissions or use IRSA
+
+### Responses are generic/unhelpful
+
+**Problem**: Model lacks context or instructions
+
+**Solution**:
+- Be more specific in queries
+- Use a more capable model
+- Provide additional context in the prompt
+
+## Example Use Cases
+
+### Scenario 1: Investigating Pod Failures
+
+**Query:**
+```
+Why are pods in the web-app deployment failing to start?
+```
+
+**Agent Actions:**
+1. Lists pods in deployment
+2. Describes failing pods
+3. Checks recent events
+4. Analyzes logs
+5. Identifies image pull error
+6. Recommends solution
+
+### Scenario 2: Capacity Planning
+
+**Query:**
+```
+Which nodes are under memory pressure? Should I scale the cluster?
+```
+
+**Agent Actions:**
+1. Runs `kubectl top nodes`
+2. Checks node conditions
+3. Reviews pod resource requests
+4. Calculates utilization
+5. Recommends scaling strategy
+
+### Scenario 3: Security Audit
+
+**Query:**
+```
+Are any pods running as root? List security concerns.
+```
+
+**Agent Actions:**
+1. Checks pod security contexts
+2. Reviews privileged containers
+3. Identifies host network usage
+4. Lists security recommendations
+
+## Uninstallation
+
+Remove the DevOps Agent:
+
+```bash
+./cli openclaw devops-agent uninstall
+```
+
+This will delete:
+- Deployment and Service
+- ServiceAccount
+- ClusterRole and ClusterRoleBinding
+- Open WebUI pipe function
+
+## References
+
+- [OpenClaw Repository](https://github.com/openclaw/openclaw)
+- [kubectl Documentation](https://kubernetes.io/docs/reference/kubectl/)
+- [Helm Documentation](https://helm.sh/docs/)
+- [AWS CLI Documentation](https://docs.aws.amazon.com/cli/)
+- [Kubernetes RBAC](https://kubernetes.io/docs/reference/access-authn-authz/rbac/)
+- [Kubernetes Audit Logging](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/)

--- a/docs/examples/openclaw/doc-writer.md
+++ b/docs/examples/openclaw/doc-writer.md
@@ -1,0 +1,298 @@
+# OpenClaw Document Writer Agent
+
+An autonomous AI-powered documentation agent that clones Git repositories, analyzes code, generates comprehensive documentation, and commits changes back to the repository. Built with OpenClaw, this agent demonstrates advanced autonomous task execution.
+
+## What It Does
+
+The Document Writer Agent:
+
+- Clones Git repositories (public or private with credentials)
+- Analyzes code structure, dependencies, and patterns
+- Generates comprehensive documentation using LLM
+- Creates or updates README, API docs, tutorials, and changelogs
+- Commits and pushes changes back to the repository
+- Streams progress updates to the user
+
+## Installation
+
+### 1. Prerequisites
+
+Install required components:
+
+```bash
+./cli ai-agent openclaw install      # OpenClaw bridge server
+./cli ai-gateway litellm install     # LiteLLM for model access
+./cli gui-app openwebui install      # Open WebUI for interaction
+```
+
+### 2. Configure Environment Variables
+
+Add to `.env.local` (via `./cli configure`):
+
+```bash
+# Required
+LITELLM_API_KEY=sk-1234567890abcdef
+
+# Optional: Git credentials for pushing changes
+OPENCLAW_DOC_WRITER_GIT_USERNAME=your-github-username
+OPENCLAW_DOC_WRITER_GIT_TOKEN=ghp_your_github_token
+
+# Optional: Observability
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+```
+
+### 3. Install Agent
+
+```bash
+./cli openclaw doc-writer install
+```
+
+This will:
+
+1. Deploy the agent as a Kubernetes Deployment
+2. Create a Service at `http://doc-writer.openclaw:8080`
+3. Automatically register the pipe function in Open WebUI
+
+## Verification
+
+Check the deployment:
+
+```bash
+# Check pods
+kubectl get pods -n openclaw -l app=doc-writer
+
+# Check service
+kubectl get svc -n openclaw doc-writer
+
+# Check logs
+kubectl logs -n openclaw -l app=doc-writer
+
+# Test health endpoint
+kubectl port-forward -n openclaw svc/doc-writer 8080:8080
+curl http://localhost:8080/health
+```
+
+## How It Works
+
+### Agent Workflow
+
+```mermaid
+graph LR
+    A[User Request] --> B[Clone Repo]
+    B --> C[Analyze Code]
+    C --> D[Generate Docs]
+    D --> E[Commit Changes]
+    E --> F[Push to GitHub]
+    F --> G[Stream Response]
+```
+
+1. **Clone**: Downloads the repository using Git credentials
+2. **Analyze**: Reads code files, understands project structure
+3. **Generate**: Uses LLM to create comprehensive documentation
+4. **Commit**: Stages and commits changes with descriptive message
+5. **Push**: Pushes changes to the remote repository
+6. **Stream**: Sends progress updates and final result to user
+
+### Git Configuration
+
+The agent is pre-configured with:
+
+```bash
+git config --system user.name "OpenClaw Doc Writer"
+git config --system user.email "openclaw-doc-writer@noreply"
+```
+
+## Open WebUI Integration
+
+The pipe function is automatically registered during installation.
+
+!!! note
+    If Open WebUI was not running during install, re-run `./cli openclaw doc-writer install`.
+
+### Using the Agent
+
+1. Open Open WebUI
+2. Start a new chat
+3. Select **OpenClaw - Document Writer** from the model dropdown
+4. Send documentation requests:
+
+**Example 1: Generate README**
+```
+Write a comprehensive README for https://github.com/myorg/myproject
+
+Include:
+- Project overview
+- Installation instructions
+- Usage examples
+- API documentation
+- Contributing guidelines
+```
+
+**Example 2: Update API Docs**
+```
+Update the API documentation in https://github.com/myorg/api-server
+
+Document all REST endpoints with:
+- Request/response formats
+- Authentication requirements
+- Error codes
+- Rate limiting
+```
+
+**Example 3: Create Changelog**
+```
+Generate a CHANGELOG.md for https://github.com/myorg/project
+
+Based on recent commits, document:
+- New features
+- Bug fixes
+- Breaking changes
+- Deprecations
+```
+
+## Configuration
+
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `OPENCLAW_GATEWAY_TOKEN` | Authentication token | `openclaw-gateway-token` |
+| `LITELLM_BASE_URL` | LiteLLM API endpoint | `http://litellm.litellm:4000` |
+| `LITELLM_API_KEY` | LiteLLM API key | From `.env` |
+| `LITELLM_MODEL_NAME` | Model to use | `bedrock/claude-4.5-sonnet` |
+| `GIT_USERNAME` | Git username for clone/push | From `.env` |
+| `GIT_TOKEN` | Git personal access token | From `.env` |
+| `LANGFUSE_HOST` | Langfuse endpoint (optional) | Auto-detected |
+
+### config.json
+
+```json
+{
+  "examples": {
+    "openclaw": {
+      "doc-writer": {
+        "env": {
+          "LITELLM_MODEL_NAME": "bedrock/claude-4.5-sonnet",
+          "OPENCLAW_GATEWAY_TOKEN": "openclaw-gateway-token"
+        }
+      }
+    }
+  }
+}
+```
+
+## Example Tasks
+
+| Task | Example Prompt |
+|------|---------------|
+| **Generate README** | Write a README for `https://github.com/user/repo` - include project description, installation steps, quick start guide, configuration options |
+| **Update API Docs** | Update the API documentation in `https://github.com/user/api-server` - REST endpoints, request/response formats, authentication, error codes |
+| **Create Changelog** | Generate a CHANGELOG.md for `https://github.com/user/project` - new features, bug fixes, breaking changes based on recent commits |
+| **Contributing Guide** | Create a CONTRIBUTING.md for `https://github.com/user/opensource-project` - code of conduct, development setup, PR process, coding standards |
+| **Architecture Docs** | Document the system architecture for `https://github.com/user/system` - components, data flow, integration points, deployment topology |
+
+## Git Credentials (Optional)
+
+The agent can push changes back to repositories with proper credentials.
+
+!!! warning "Security Warning"
+    Git credentials are injected as **plain-text environment variables**. The LLM-driven agent has access to these at runtime. A prompt injection attack could potentially leak or misuse the token. **Do not use tokens with broad access.**
+
+### Creating a Scoped GitHub Token
+
+Use a [fine-grained personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-fine-grained-personal-access-token):
+
+1. Go to **GitHub Settings** → **Developer settings** → **Personal access tokens** → **Fine-grained tokens**
+2. Click **Generate new token**
+3. Configure:
+   - **Token name**: `openclaw-doc-writer`
+   - **Expiration**: 30 days (or shorter)
+   - **Repository access**: **Only select repositories** - pick specific repos
+   - **Permissions**: Set **Contents** to **Read and write** - leave everything else at **No access**
+4. Generate token and add to `.env.local`:
+
+```bash
+OPENCLAW_DOC_WRITER_GIT_USERNAME=your-github-username
+OPENCLAW_DOC_WRITER_GIT_TOKEN=ghp_your_fine_grained_token
+```
+
+### Recommendations
+
+- ❌ **Never use classic tokens** - they grant access to all repos
+- ✅ **Set short expiration** - rotate tokens frequently
+- ✅ **Limit to specific repos** - never grant org-wide access
+- ✅ **Review agent output** - check commits before merging
+- ✅ **Use branch protection** - require reviews for main branches
+- ✅ For production, consider AWS Secrets Manager instead of env vars
+
+### Without Credentials
+
+The agent can still operate without credentials:
+
+- ✅ Clone public repositories
+- ✅ Analyze code and generate documentation
+- ❌ Cannot commit and push changes
+- Agent will provide documentation as text response instead
+
+## Langfuse Observability
+
+If Langfuse is installed, view agent execution traces:
+
+1. Open Langfuse UI
+2. Navigate to **Traces**
+3. Filter by `doc-writer` tag
+4. View detailed metrics:
+   - Task submission time
+   - Git operations (clone, commit, push)
+   - LLM API calls with prompts and responses
+   - Token usage and costs
+   - Response latency
+   - Error events
+
+## Cost Optimization
+
+- **Spot instances**: Karpenter provisions Spot ARM64 nodes (up to 90% savings)
+- **Model selection**: Use smaller models for simpler docs
+- **Job-based execution**: Consider using Jobs instead of Deployment for one-off tasks
+- **Prompt optimization**: Be specific to reduce unnecessary LLM calls
+
+## Troubleshooting
+
+### Agent cannot clone private repos
+
+**Problem**: `fatal: could not read Username`
+
+**Solution**: Configure Git credentials in `.env.local`
+
+### Agent cannot push changes
+
+**Problem**: `remote: Permission denied`
+
+**Solution**: Ensure GitHub token has **Contents: Read and write** permission
+
+### Documentation quality is poor
+
+**Problem**: Generated docs lack detail
+
+**Solution**: 
+- Be specific in prompts about what to include
+- Use a more capable model (e.g., Claude 3.5 Sonnet)
+- Provide example documentation style
+
+## Uninstallation
+
+Remove the Document Writer Agent:
+
+```bash
+./cli openclaw doc-writer uninstall
+```
+
+This will delete Kubernetes resources (Deployment, Service, ServiceAccount) and the Open WebUI pipe function.
+
+## References
+
+- [OpenClaw Repository](https://github.com/openclaw/openclaw)
+- [Open WebUI Pipe Functions](https://docs.openwebui.com/features/pipe-functions)
+- [GitHub Personal Access Tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
+- [Git Credential Storage](https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)

--- a/docs/examples/strands-agents/calculator-agent.md
+++ b/docs/examples/strands-agents/calculator-agent.md
@@ -1,0 +1,261 @@
+# Strands Agents Calculator Agent
+
+An AI agent built with the Strands framework that performs arithmetic calculations using either MCP tools or native Python tools. The agent demonstrates integration with LiteLLM, Bedrock, and optional observability with Langfuse.
+
+## What It Does
+
+The Calculator Agent:
+
+- Accepts natural language calculation requests via HTTP API
+- Uses AI models (Claude, GPT, etc.) to understand requests
+- Executes calculations using MCP tools or Python calculator tools
+- Streams responses back to clients
+- Optionally traces execution to Langfuse for observability
+
+## Installation
+
+Install the Strands Calculator Agent:
+
+```bash
+./cli strands-agents calculator-agent install
+```
+
+This will:
+
+1. Build a Docker image containing the Strands agent code
+2. Push the image to Amazon ECR
+3. Deploy the agent as a Kubernetes Deployment
+4. Create a Service at `http://calculator-agent.strands-agents:8080`
+5. Register the agent as a pipe function in Open WebUI (if installed)
+
+## Verification
+
+Check the deployment status:
+
+```bash
+# Check pods
+kubectl get pods -n strands-agents -l app=calculator-agent
+
+# Check service
+kubectl get svc -n strands-agents calculator-agent
+
+# Check logs
+kubectl logs -n strands-agents -l app=calculator-agent
+
+# Test agent endpoint
+kubectl port-forward -n strands-agents svc/calculator-agent 8080:8080
+curl -X POST http://localhost:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is 25 multiplied by 4?"}'
+```
+
+## Key Files
+
+### agent.py
+
+The main Strands agent implementation using FastAPI:
+
+```python
+from strands import Agent
+from strands.models.litellm import LiteLLMModel
+from strands_tools import calculator
+from strands.tools.mcp.mcp_client import MCPClient
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+# Configure model (LiteLLM or Bedrock)
+if os.environ.get("USE_BEDROCK", "").lower() == "true":
+    model = BedrockModel(model_id=os.environ.get("BEDROCK_MODEL"))
+else:
+    model = LiteLLMModel(
+        client_args={
+            "base_url": f"{os.environ.get("LITELLM_BASE_URL")}/v1",
+            "api_key": os.environ.get("LITELLM_API_KEY"),
+        },
+        model_id="openai/" + os.environ.get("LITELLM_MODEL_NAME"),
+    )
+
+# Configure tools (MCP or Python)
+if os.environ.get("USE_MCP_TOOLS", "").lower() == "true":
+    mcp_client = MCPClient(
+        lambda: streamablehttp_client("http://calculator.mcp-server:8000/mcp")
+    )
+    tools = mcp_client.list_tools_sync()
+else:
+    tools = [calculator]
+
+agent = Agent(model=model, system_prompt=system_prompt, tools=tools)
+
+@app.post("/")
+async def prompt(request: PromptRequest):
+    async def process_streaming_response():
+        async for event in agent.stream_async(request.prompt):
+            if "data" in event:
+                yield event["data"]
+    return StreamingResponse(process_streaming_response(), media_type="text/plain")
+```
+
+### openwebui_pipe_function.py
+
+Open WebUI integration for interactive chat:
+
+```python
+class Pipe:
+    def __init__(self):
+        self.type = "manifold"
+        self.id = "strands_calculator_agent"
+        self.name = "Strands: Calculator Agent"
+    
+    def pipe(self, body: dict) -> str:
+        # Forward request to agent service
+        response = requests.post(
+            "http://calculator-agent.strands-agents:8080",
+            json={"prompt": user_message}
+        )
+        return response.text
+```
+
+### Dockerfile
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY agent.py .
+EXPOSE 8080
+CMD ["uvicorn", "agent:app", "--host", "0.0.0.0", "--port", "8080"]
+```
+
+## How It Works
+
+1. **Request Reception**: The FastAPI server receives POST requests with calculation prompts
+2. **Agent Processing**: The Strands Agent uses the configured model to understand the request
+3. **Tool Execution**: The agent calls appropriate calculator tools (add, subtract, multiply, divide)
+4. **Response Streaming**: Results are streamed back to the client in real-time
+5. **Observability**: If Langfuse is configured, execution traces are automatically captured
+
+### MCP vs Python Tools
+
+The agent supports two tool modes:
+
+**MCP Tools** (when `USE_MCP_TOOLS=true`):
+- Connects to the Calculator MCP Server
+- Uses standardized MCP protocol
+- Requires MCP server to be installed
+
+**Python Tools** (default):
+- Uses native Python calculator functions
+- No external dependencies
+- Faster execution (no network calls)
+
+## Configuration
+
+Configure the agent via environment variables in `.env.local` or `config.json`:
+
+```json
+{
+  "examples": {
+    "strands-agents": {
+      "calculator-agent": {
+        "env": {
+          "USE_MCP_TOOLS": "false",
+          "USE_MCP_GATEWAY": "false",
+          "USE_BEDROCK": "false",
+          "LITELLM_MODEL_NAME": "bedrock/claude-4.5-sonnet",
+          "LITELLM_BASE_URL": "http://litellm.litellm:4000",
+          "LITELLM_API_KEY": "${LITELLM_API_KEY}"
+        }
+      }
+    }
+  }
+}
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `USE_MCP_TOOLS` | Use MCP tools instead of Python tools | `false` |
+| `USE_MCP_GATEWAY` | Use LiteLLM MCP gateway proxy | `false` |
+| `USE_BEDROCK` | Use Bedrock instead of LiteLLM | `false` |
+| `LITELLM_BASE_URL` | LiteLLM API endpoint | `http://litellm.litellm:4000` |
+| `LITELLM_API_KEY` | LiteLLM API key | From `.env` |
+| `LITELLM_MODEL_NAME` | Model to use | `bedrock/claude-4.5-sonnet` |
+| `BEDROCK_MODEL` | Bedrock model ID | `us.anthropic.claude-3-7-sonnet-20250219-v1:0` |
+| `LANGFUSE_HOST` | Langfuse endpoint (optional) | Auto-detected |
+| `LANGFUSE_PUBLIC_KEY` | Langfuse public key (optional) | From `.env` |
+| `LANGFUSE_SECRET_KEY` | Langfuse secret key (optional) | From `.env` |
+
+## Open WebUI Integration
+
+The agent is automatically registered in Open WebUI during installation. No manual setup is needed.
+
+!!! note
+    If Open WebUI was not running during install, re-run `./cli strands-agents calculator-agent install` to register the pipe function.
+
+### Using the Agent
+
+1. Open Open WebUI in your browser
+2. Start a new chat
+3. Select **Strands: Calculator Agent** from the model dropdown
+4. Send calculation requests:
+
+```
+What is 125 divided by 5?
+Calculate 15% of 200
+What is the product of 12 and 8?
+```
+
+## Example Requests
+
+### Direct API
+
+```bash
+# Simple calculation
+curl -X POST http://calculator-agent.strands-agents:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "What is 25 multiplied by 4?"}'
+
+# Multiple operations
+curl -X POST http://calculator-agent.strands-agents:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Calculate (100 + 50) divided by 3"}'
+
+# Word problems
+curl -X POST http://calculator-agent.strands-agents:8080/ \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "If I have 120 apples and give away 45, how many do I have left?"}'
+```
+
+## Langfuse Observability
+
+If Langfuse is installed and configured, the agent automatically sends traces:
+
+1. Open Langfuse UI
+2. Navigate to **Traces**
+3. Filter by session or user
+4. View detailed execution traces including:
+   - Model calls and responses
+   - Tool invocations
+   - Token usage
+   - Latency metrics
+   - Error events
+
+## Uninstallation
+
+Remove the Calculator Agent:
+
+```bash
+./cli strands-agents calculator-agent uninstall
+```
+
+This will delete the Deployment, Service, and Open WebUI pipe function.
+
+## References
+
+- [Strands Agents Documentation](https://strandsagents.com)
+- [FastAPI Documentation](https://fastapi.tiangolo.com)
+- [LiteLLM Documentation](https://docs.litellm.ai)
+- [Model Context Protocol](https://modelcontextprotocol.io)

--- a/docs/getting-started/demo-walkthrough.md
+++ b/docs/getting-started/demo-walkthrough.md
@@ -1,0 +1,316 @@
+# Demo Walkthrough
+
+This guide walks you through the demo environment deployed by `./cli demo-setup`, including setup steps and usage instructions for each component.
+
+## Deployed Components
+
+The demo environment includes:
+
+### AI Gateway
+
+**LiteLLM**
+
+- Unified API gateway for multiple LLM providers
+- Request routing and load balancing
+- Usage tracking and observability
+- Access: `litellm.<DOMAIN>/ui`
+
+### LLM Models
+
+**vLLM with Qwen3 Models**
+
+Two models are deployed:
+
+| Model | Quantization | Hardware | Performance | Mode |
+|-------|-------------|----------|-------------|------|
+| [Qwen3-30B-A3B-Instruct-2507-FP8](https://huggingface.co/Qwen/Qwen3-30B-A3B-Instruct-2507-FP8) | FP8 (8-bit) | Single g6e | ~75 tokens/sec | MoE, non-thinking |
+| [Qwen3-32B-FP8](https://huggingface.co/Qwen/Qwen3-32B-FP8) | FP8 (8-bit) | Single g6e | ~15 tokens/sec | Dense, thinking & non-thinking |
+
+!!! info "Model Characteristics"
+    - **Fast Model**: MoE architecture optimized for speed
+    - **Slow Model**: Dense model with reasoning capabilities
+
+### Observability
+
+**Langfuse**
+
+- LLM observability and analytics
+- Trace tracking and debugging
+- Cost and performance monitoring
+- Access: `langfuse.<DOMAIN>`
+
+### GUI Application
+
+**Open WebUI**
+
+- Chat interface for LLM interaction
+- Document RAG capabilities
+- AI agent integration
+- Function/tool marketplace
+- Access: `openwebui.<DOMAIN>`
+
+### Vector Database
+
+**Qdrant**
+
+- High-performance vector database
+- Used for RAG document embeddings
+- REST and gRPC API support
+
+### Embedding Models
+
+**Text Embedding Inference (TEI) with Qwen3-Embedding**
+
+| Model | Quantization | Hardware |
+|-------|-------------|----------|
+| [Qwen3-Embedding-4B](https://huggingface.co/Qwen/Qwen3-Embedding-4B) | BF16 (16-bit) | Single r7i |
+
+### MCP Server
+
+**Calculator MCP Server**
+
+- Built with FastMCP 2.0
+- Basic calculator operations
+- Demonstrates MCP server implementation
+
+### AI Agent
+
+**Strands Calculator Agent**
+
+- Built with Strands Agents framework
+- Stateful calculator with memory
+- Integrated with Open WebUI
+
+## Demo Setup
+
+After running `./cli demo-setup`, configure Open WebUI:
+
+### 1. Access Open WebUI
+
+Navigate to `openwebui.<DOMAIN>` in your browser.
+
+### 2. Agent Functions (Auto-Registered)
+
+Agent pipe functions are automatically registered when agents are installed:
+
+```bash
+./cli strands-agents calculator-agent install
+```
+
+The `Strands Agents - Calculator Agent` function appears in Open WebUI automatically.
+
+### 3. Add Optional Functions
+
+Add the Time Token Tracker function from the marketplace:
+
+1. Navigate to Functions in Open WebUI
+2. Search for "Time Token Tracker"
+3. Click install
+
+[Time Token Tracker on Open WebUI →](https://openwebui.com/f/owndev/time_token_tracker)
+
+See [Open WebUI Functions documentation](https://docs.openwebui.com/features/plugin/functions/#%EF%B8%8F-how-to-use-functions) for more details.
+
+### 4. Configure RAG Embedding Model
+
+Set up Open WebUI to use the deployed Qwen3-Embedding model:
+
+1. Navigate to **Admin Panel** → **Settings** → **Documents**
+2. Set the embedding model endpoint
+3. Get the API key from `.env.local` (check `LITELLM_API_KEY`)
+4. Save configuration
+
+[RAG Embedding Support documentation →](https://docs.openwebui.com/features/rag#rag-embedding-support)
+
+## Using the Demo
+
+### Chat with LLM Models
+
+Interact with deployed models through Open WebUI:
+
+1. **Start a Conversation**
+    - Select a model from the dropdown
+    - Type your message and press Enter
+    - Try both the fast and slow models
+
+2. **Compare Models**
+    - Fast model (Qwen3-30B-A3B): Better for quick responses
+    - Slow model (Qwen3-32B): Better for complex reasoning
+
+[Chat Features Overview →](https://docs.openwebui.com/features/chat-features)
+
+!!! tip "Model Selection"
+    Use the fast model for general chat and the slow model when you need detailed reasoning or step-by-step thinking.
+
+### Document RAG
+
+Use the RAG feature to chat with your documents:
+
+1. **Upload Documents**
+    - Click the document icon in the chat interface
+    - Select files to upload (PDF, TXT, DOCX, etc.)
+    - Wait for embedding processing
+
+2. **Query Documents**
+    - Ask questions about uploaded documents
+    - The system retrieves relevant chunks using Qdrant
+    - Responses are grounded in your documents
+
+3. **Manage Collections**
+    - View and organize document collections
+    - Update or delete documents as needed
+
+[RAG Tutorial →](https://docs.openwebui.com/tutorials/tips/rag-tutorial)
+
+### Calculator Agent
+
+Explore the Strands Calculator Agent:
+
+1. **Select the Agent**
+    - In Open WebUI, select `Strands Agents - Calculator Agent`
+    - The agent maintains memory across conversations
+
+2. **Perform Calculations**
+    ```
+    You: Add 15 and 27
+    Agent: The result is 42
+
+    You: Multiply that by 2
+    Agent: The result is 84
+
+    You: What's the current total?
+    Agent: 84
+    ```
+
+3. **Reset Calculator**
+    ```
+    You: Reset the calculator
+    Agent: Calculator has been reset
+    ```
+
+!!! example "Agent Features"
+    - **Memory**: Continues calculations across messages
+    - **Context Aware**: Understands "that" and "the result"
+    - **Stateful**: Maintains current value
+
+**Source Code**: `examples/strands-agents/calculator-agent/`
+
+### LiteLLM Dashboard
+
+Monitor and manage API requests:
+
+1. **Access Dashboard**
+    - Navigate to `litellm.<DOMAIN>/ui`
+    - Credentials in `.env.local`:
+        - Username: `LITELLM_UI_USERNAME`
+        - Password: `LITELLM_UI_PASSWORD`
+
+2. **Features**
+    - Request logs and metrics
+    - Model routing configuration
+    - Rate limiting and budgets
+    - API key management
+
+[LiteLLM Proxy Server documentation →](https://docs.litellm.ai/docs/simple_proxy)
+
+!!! info "Request Flow"
+    Open WebUI → LiteLLM Proxy → vLLM/Model
+
+### Langfuse Dashboard
+
+Track LLM observability and analytics:
+
+1. **Access Dashboard**
+    - Navigate to `langfuse.<DOMAIN>`
+    - Credentials in `.env.local`:
+        - Email: `LANGFUSE_USERNAME`
+        - Password: `LANGFUSE_PASSWORD`
+
+2. **Features**
+    - Trace visualization
+    - Cost tracking
+    - Performance metrics
+    - User analytics
+    - Model comparisons
+
+3. **Integration**
+    - LiteLLM automatically logs to Langfuse
+    - All requests from Open WebUI are tracked
+    - Agent interactions are captured
+
+[Langfuse Features →](https://langfuse.com/docs/core-features)
+
+## Verification
+
+Verify all components are running:
+
+```bash
+# Check pods
+kubectl get pods -n litellm
+kubectl get pods -n vllm
+kubectl get pods -n langfuse
+kubectl get pods -n openwebui
+kubectl get pods -n qdrant
+kubectl get pods -n tei
+
+# Check services
+kubectl get svc --all-namespaces
+
+# Check ingress endpoints
+kubectl get ingress --all-namespaces
+```
+
+All pods should show `Running` status.
+
+## Troubleshooting
+
+### Component Not Accessible
+
+Check ingress and service configuration:
+
+```bash
+kubectl describe ingress <name> -n <namespace>
+kubectl describe svc <name> -n <namespace>
+```
+
+### Model Not Loading
+
+Check pod logs:
+
+```bash
+kubectl logs -f deploy/vllm-<model> -n vllm
+```
+
+Common issues:
+
+- Insufficient GPU memory
+- Model download in progress
+- Incorrect model path
+
+### RAG Not Working
+
+Verify embedding model:
+
+```bash
+kubectl get pods -n tei
+kubectl logs -f deploy/tei-qwen3-embedding -n tei
+```
+
+Check Open WebUI embedding configuration in Admin Panel.
+
+## Next Steps
+
+- Explore different models and their capabilities
+- Build custom agents using the Strands Agents framework
+- Create MCP servers with FastMCP 2.0
+- Integrate with your own applications via LiteLLM API
+- Monitor costs and performance with Langfuse
+
+## Reference Materials
+
+- [Open WebUI Documentation](https://docs.openwebui.com)
+- [LiteLLM Documentation](https://docs.litellm.ai)
+- [Langfuse Documentation](https://langfuse.com/docs)
+- [vLLM Documentation](https://docs.vllm.ai)
+- [Strands Agents Documentation](https://strandsagents.com)
+- [FastMCP Documentation](https://gofastmcp.com)

--- a/docs/getting-started/infrastructure.md
+++ b/docs/getting-started/infrastructure.md
@@ -1,0 +1,288 @@
+# Infrastructure Setup
+
+The GenAI on EKS Starter Kit provisions AWS infrastructure and Kubernetes components using Terraform. All infrastructure code is located in the `terraform/` directory.
+
+## AWS Services
+
+The following AWS services are provisioned:
+
+### VPC and Networking
+
+- **VPC**: One Virtual Private Cloud with private and public subnets
+- **NAT Gateway**: Single NAT gateway for outbound internet access from private subnets
+- **Subnets**: Public and private subnets across multiple availability zones
+
+### Amazon EKS
+
+- **EKS Cluster**: One EKS cluster in Auto Mode (default) or Standard Mode
+- **EKS_MODE**: Configure via environment variable
+    - `auto` (default): EKS Auto Mode with managed compute
+    - `standard`: Standard EKS with self-managed node groups
+
+!!! info "EKS Auto Mode"
+    EKS Auto Mode automatically provisions and manages compute resources, simplifying cluster operations and reducing operational overhead.
+
+### Amazon EFS
+
+- **EFS File System**: Shared file system for:
+    - Caching Hugging Face models
+    - Persistent storage for AI workloads
+    - Compiled Neuron models for AWS Inferentia
+
+The EFS file system is mounted to pods that require persistent storage.
+
+### AWS Certificate Manager (ACM)
+
+- **Wildcard Certificate**: Automatically provisioned for your domain
+- **Domain Validation**: Uses DNS validation via Route 53
+- **Coverage**: `*.<DOMAIN>` allows all subdomains
+
+!!! note "Domain Requirement"
+    ACM certificate is only created when `DOMAIN` is configured. Without a domain, services use HTTP with multiple ALBs.
+
+## Kubernetes Components
+
+The following Kubernetes components are deployed on the EKS cluster:
+
+### Ingress and Load Balancing
+
+**AWS Load Balancer Controller**
+
+- Provisions shared Application Load Balancer (ALB)
+- Manages ingress resources
+- Integrates with ACM for TLS termination
+
+**Ingress Configuration**
+
+- **With Domain**: Single shared ALB with HTTPS
+- **Without Domain**: Multiple ALBs with HTTP per service
+
+### DNS Management
+
+**ExternalDNS**
+
+- Automatically creates Route 53 DNS records for services
+- Syncs with Kubernetes ingress resources
+- Manages records for public-facing services
+
+!!! example "Automatic DNS Records"
+    When you deploy LiteLLM, ExternalDNS automatically creates `litellm.<DOMAIN>` pointing to the ALB.
+
+### Authentication
+
+**Ingress NGINX Controller**
+
+- Provides HTTP Basic authentication for services
+- Used for services requiring access control:
+    - Qdrant vector database
+    - Milvus vector database
+    - Monitoring dashboards
+
+!!! warning "Domain Limitation"
+    Without a domain, only one service with Nginx Ingress basic auth can be exposed due to multiple ALB limitations.
+
+### Storage
+
+**EFS CSI Driver**
+
+- Enables EFS file system mounting in pods
+- Provides persistent storage for AI models
+- Supports ReadWriteMany access mode
+
+**Storage Classes**
+
+Two storage classes are configured:
+
+| Storage Class | Type | Use Case |
+|--------------|------|----------|
+| `ebs-gp3` | EBS GP3 | Block storage for individual pods |
+| `efs` | EFS | Shared storage across pods |
+
+```yaml
+# Example: Using EFS storage
+persistentVolumeClaim:
+  storageClass: efs
+  size: 100Gi
+```
+
+## Infrastructure Management
+
+### Terraform Workspaces
+
+Multiple EKS clusters are supported using Terraform workspaces:
+
+- Workspace name is derived from `REGION` and `EKS_CLUSTER_NAME`
+- Each cluster has isolated Terraform state
+- Switch clusters by changing environment variables
+
+### Apply Infrastructure Changes
+
+Apply Terraform changes manually:
+
+```bash
+./cli terraform apply
+```
+
+### View Infrastructure State
+
+Check current Terraform state:
+
+```bash
+./cli terraform show
+```
+
+### Destroy Infrastructure
+
+Remove all provisioned infrastructure:
+
+```bash
+./cli cleanup-infra
+```
+
+!!! danger "Destructive Operation"
+    This destroys all AWS resources. Ensure you've backed up any data and uninstalled components first.
+
+## GPU Instance Configuration
+
+### Default Configuration
+
+- **Instance Families**: g6e, g6, g5g
+- **Purchasing Options**: Spot and On-Demand
+
+### Customization
+
+Modify `terraform/0-common.tf` to change:
+
+- GPU instance families
+- Purchasing options (Spot vs On-Demand)
+- Instance size and count limits
+
+```hcl
+# Example: terraform/0-common.tf
+variable "gpu_instance_families" {
+  default = ["g6e", "g6", "g5g"]
+}
+```
+
+After changes, apply the configuration:
+
+```bash
+./cli terraform apply
+```
+
+!!! note "Node Selectors"
+    Model deployment manifests use `nodeSelector` to target specific instance families. Update manifests accordingly when changing instance families.
+
+## AWS Neuron and Inferentia Support
+
+For LLM inference on AWS Inferentia 2 instances:
+
+1. Enable Neuron in configuration:
+
+    ```json
+    // config.json or config.local.json
+    {
+      "enableNeuron": true
+    }
+    ```
+
+2. Reinstall the component:
+
+    ```bash
+    ./cli llm-model vllm install
+    ```
+
+    This builds and pushes the vLLM Neuron container image to ECR (20-30 minutes).
+
+3. First deployment compiles the model (20-30 minutes)
+4. Compiled models are cached on EFS for subsequent deployments
+
+### INT8 Quantization on inf2.xlarge
+
+Models like Llama-3.1-8B-Instruct support INT8 quantization for single inf2.xlarge, but require inf2.8xlarge for compilation:
+
+1. Deploy with compilation enabled (uses inf2.8xlarge)
+2. Change `"compile": true` to `"compile": false` in config
+3. Delete and redeploy (uses inf2.xlarge)
+
+## ECR Pull Through Cache
+
+Cache external container images in your private ECR registry.
+
+### Default: Disabled
+
+ECR Pull Through Cache is disabled by default to avoid storage costs.
+
+### When to Enable
+
+- Hitting Docker Hub rate limits
+- Require faster, more reliable pulls from within AWS
+- Organization policies require private registry storage
+
+### Configuration
+
+1. Get Docker Hub credentials:
+    - Create account at [hub.docker.com](https://hub.docker.com)
+    - Generate access token at [Security Settings](https://hub.docker.com/settings/security)
+
+2. Get GitHub credentials:
+    - Generate Personal Access Token at [GitHub Settings](https://github.com/settings/tokens)
+    - Requires `read:packages` scope
+
+3. Configure in `config.local.json`:
+
+    ```json
+    {
+      "terraform": {
+        "vars": {
+          "enable_ecr_pull_through_cache": true,
+          "dockerhub_username": "your-username",
+          "dockerhub_access_token": "your-token",
+          "github_username": "your-username",
+          "github_token": "your-token"
+        }
+      }
+    }
+    ```
+
+4. Apply changes:
+
+    ```bash
+    ./cli terraform apply
+    ```
+
+### Supported Registries
+
+- `vllm/*` → Docker Hub
+- `lmsysorg/*` → Docker Hub
+- `ollama/*` → Docker Hub
+- `huggingface/*` → GitHub Container Registry
+
+!!! warning "Manual Cleanup Required"
+    `terraform destroy` removes cache rules but not cached repositories. Manually delete repositories starting with `vllm/`, `lmsysorg/`, `ollama/`, or `huggingface/` from ECR.
+
+## Multi-Cluster Management
+
+Provision and manage multiple EKS clusters:
+
+1. Change environment variables in `.env.local`:
+
+    ```bash
+    REGION=us-east-1
+    EKS_CLUSTER_NAME=genai-dev
+    DOMAIN=dev.example.com
+    ```
+
+2. Run setup:
+
+    ```bash
+    ./cli demo-setup
+    ```
+
+Terraform workspace and kubectl context automatically use the configured values.
+
+## Next Steps
+
+- Return to [Quick Start](quick-start.md) to deploy components
+- Follow the [Demo Walkthrough](demo-walkthrough.md) to explore features
+- Check [Security Considerations](../reference/security.md) for best practices

--- a/docs/getting-started/prerequisites.md
+++ b/docs/getting-started/prerequisites.md
@@ -1,0 +1,112 @@
+# Prerequisites
+
+Before you begin using the GenAI on EKS Starter Kit, ensure you have the following tools and access configured.
+
+## Required Tools
+
+Install these tools before proceeding with the setup:
+
+### AWS CLI
+
+The AWS Command Line Interface for interacting with AWS services.
+
+[Install AWS CLI :octicons-arrow-right-24:](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html){ .md-button }
+
+### Terraform
+
+Infrastructure as Code tool for provisioning AWS resources.
+
+[Install Terraform :octicons-arrow-right-24:](https://www.terraform.io/downloads){ .md-button }
+
+### Node.js
+
+JavaScript runtime required for the CLI tool and configuration management.
+
+[Install Node.js :octicons-arrow-right-24:](https://nodejs.org/en/download){ .md-button }
+
+### kubectl
+
+Kubernetes command-line tool for cluster management.
+
+[Install kubectl :octicons-arrow-right-24:](https://kubernetes.io/docs/tasks/tools){ .md-button }
+
+### Helm
+
+Package manager for Kubernetes applications.
+
+[Install Helm :octicons-arrow-right-24:](https://helm.sh/docs/intro/install){ .md-button }
+
+### Docker and Buildx
+
+Container platform and multi-architecture build plugin.
+
+- [Install Docker :octicons-arrow-right-24:](https://docs.docker.com/get-started/)
+- [Install Buildx :octicons-arrow-right-24:](https://docs.docker.com/build/concepts/overview/#buildx)
+
+!!! note "Multi-Architecture Builds"
+    By default, `docker buildx` is used to build multi-arch container images. You can disable this by modifying the `docker` section in `config.json` or `config.local.json`.
+
+## AWS Account Requirements
+
+You'll need an AWS account with appropriate permissions to:
+
+- Create VPC, subnets, and networking resources
+- Provision EKS clusters and node groups
+- Create EFS file systems
+- Manage Route 53 hosted zones and DNS records
+- Request and manage ACM certificates
+- Create and manage ECR repositories
+- Deploy EC2 instances (including GPU instances)
+
+!!! warning "IAM Permissions"
+    Ensure your AWS credentials have sufficient permissions to create and manage these resources. Administrator access is recommended for initial setup.
+
+## Optional Components
+
+### Hugging Face Account
+
+Required if you plan to use models that require authentication.
+
+- Create an account at [huggingface.co](https://huggingface.co)
+- Generate a user access token at [Hugging Face Security Settings](https://huggingface.co/settings/tokens)
+
+See [User access tokens documentation](https://huggingface.co/docs/hub/en/security-tokens) for more details.
+
+### Route 53 Hosted Zone
+
+A domain name configured with a Route 53 hosted zone is recommended but not required.
+
+**With a domain:**
+
+- Single shared ALB with HTTPS
+- Wildcard ACM certificate
+- Services exposed at `service.<DOMAIN>` (e.g., `litellm.example.com`)
+
+**Without a domain:**
+
+- Multiple ALBs with HTTP
+- Individual ALB per public-facing service
+- Limited to one service with Nginx Ingress basic auth
+
+!!! tip "Domain Configuration"
+    If you don't have a domain yet but plan to use one, set it up before running the initial configuration to avoid reconfiguration later.
+
+## Verification
+
+After installing all tools, verify they're available:
+
+```bash
+aws --version
+terraform --version
+node --version
+kubectl version --client
+helm version
+docker --version
+docker buildx version
+```
+
+All commands should return version information without errors.
+
+## Next Steps
+
+Once you have all prerequisites installed, proceed to the [Quick Start](quick-start.md) guide.

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -1,0 +1,275 @@
+# Quick Start
+
+This guide will help you set up and deploy the GenAI on EKS Starter Kit.
+
+## Initial Setup
+
+### 1. Install Dependencies
+
+Clone the repository and install Node.js dependencies:
+
+```bash
+npm install
+```
+
+### 2. Configure Environment
+
+Run the configuration command to set up environment variables:
+
+```bash
+./cli configure
+```
+
+You'll be prompted to enter values for key environment variables:
+
+```bash
+✔ Enter value for REGION: us-west-2
+✔ Enter value for EKS_CLUSTER_NAME: genai-on-eks
+✔ Enter value for DOMAIN: 
+```
+
+The values are saved to `.env.local`.
+
+#### Key Environment Variables
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `REGION` | AWS region for infrastructure | `us-west-2` |
+| `EKS_CLUSTER_NAME` | Name of the EKS cluster | `genai-on-eks` |
+| `EKS_MODE` | EKS mode: `auto` (default) or `standard` | `auto` |
+| `DOMAIN` | Domain name with Route 53 hosted zone (optional) | `example.com` |
+| `HF_TOKEN` | Hugging Face user access token | `hf_...` |
+
+!!! tip "Configuration Hierarchy"
+    Configuration files are loaded in order with later sources overriding earlier ones:
+    
+    `.env` → `config.json` → `.env.local` → `config.local.json`
+
+## Environment Setup
+
+Choose one of two setup methods:
+
+=== "Method 1: Quick Demo Setup"
+
+    Deploy a curated demo environment with essential components:
+
+    ```bash
+    ./cli demo-setup
+    ```
+
+    This command will:
+
+    1. Provision AWS infrastructure using Terraform ([details](infrastructure.md))
+    2. Deploy demo components and examples in the correct order:
+        - LiteLLM (AI Gateway)
+        - vLLM with Qwen3 models
+        - Langfuse (Observability)
+        - Open WebUI (GUI)
+        - Qdrant (Vector Database)
+        - TEI with Qwen3-Embedding model
+        - Calculator MCP Server
+        - Strands Calculator Agent
+
+    See the [Demo Walkthrough](demo-walkthrough.md) for usage instructions.
+
+=== "Method 2: Interactive Setup"
+
+    Customize your setup by selecting specific components:
+
+    ```bash
+    ./cli interactive-setup
+    ```
+
+    You'll be presented with a menu to select components by category:
+
+    ```bash
+    ✔ Select AI Gateway components to install: litellm
+    ✔ Select LLM Model components to install: vllm
+    ? Select Embedding Model components to install: 
+      ❯◉ Text Embedding Inference (TEI)
+    ```
+
+    This command will:
+
+    1. Prompt you to select components and examples
+    2. Provision infrastructure using Terraform
+    3. Install all selected components
+
+    !!! warning "Deployment Order"
+        Unlike the demo setup, components may not be deployed in the required order. Some components may need to be reinstalled by running the CLI install command again.
+
+## NVIDIA Dynamo Platform Setup
+
+For optimized LLM inference with NVIDIA Dynamo on EKS:
+
+### Installation Order
+
+Install components sequentially:
+
+```bash
+# 1. Monitoring stack
+./cli nvidia-platform monitoring install
+
+# 2. GPU operator
+./cli nvidia-platform gpu-operator install
+
+# 3. Dynamo platform
+./cli nvidia-platform dynamo-platform install
+
+# 4. Deploy a model with vLLM
+./cli nvidia-platform dynamo-vllm install
+```
+
+### Optional Components
+
+Run benchmarks and auto-configuration:
+
+```bash
+# Concurrency sweep benchmarks
+./cli nvidia-platform benchmark install
+
+# TP/PP recommendations and SLA deployment
+./cli nvidia-platform aiconfigurator install
+```
+
+For full details on platform prerequisites, deployment modes, KV cache routing, monitoring, and benchmarking, see the [NVIDIA Platform Overview](../components/nvidia-platform/index.md).
+
+## Component Management
+
+### Install a Component or Example
+
+```bash
+./cli <category> <component> install
+```
+
+**Examples:**
+
+```bash
+./cli ai-gateway litellm install
+./cli llm-model vllm install
+./cli strands-agents calculator-agent install
+```
+
+### Uninstall a Component or Example
+
+```bash
+./cli <category> <component> uninstall
+```
+
+**Examples:**
+
+```bash
+./cli ai-gateway litellm uninstall
+./cli llm-model vllm uninstall
+./cli strands-agents calculator-agent uninstall
+```
+
+## Model Management
+
+Manage LLM and embedding models for hosting components:
+
+### Configure Models
+
+Set which models should be deployed:
+
+```bash
+./cli llm-model <component> configure-models
+./cli embedding-model <component> configure-models
+```
+
+**Examples:**
+
+```bash
+./cli llm-model vllm configure-models
+./cli embedding-model tei configure-models
+```
+
+### Update Models
+
+Add and/or remove models:
+
+```bash
+./cli llm-model <component> update-models
+./cli embedding-model <component> update-models
+```
+
+### Add Models
+
+Add missing models only:
+
+```bash
+./cli llm-model <component> add-models
+./cli embedding-model <component> add-models
+```
+
+### Remove All Models
+
+Remove all models for a component:
+
+```bash
+./cli llm-model <component> remove-all-models
+./cli embedding-model <component> remove-all-models
+```
+
+!!! tip "LiteLLM Model Updates"
+    Run `./cli litellm install` again to update the LiteLLM proxy model list. Bedrock models are configured in `config.json`.
+
+## Cleanup
+
+Choose one of two cleanup methods:
+
+=== "Method 1: Selective Cleanup"
+
+    Uninstall components individually, then destroy infrastructure:
+
+    ```bash
+    # Uninstall each component
+    ./cli strands-agents calculator-agent uninstall
+    ./cli ai-gateway litellm uninstall
+    # ... uninstall other components as needed
+
+    # Destroy infrastructure
+    ./cli cleanup-infra
+    ```
+
+    This method gives you precise control over the cleanup process.
+
+=== "Method 2: Complete Cleanup"
+
+    Remove everything in one command:
+
+    ```bash
+    ./cli cleanup-everything
+    ```
+
+    This command will:
+
+    1. Uninstall all deployed examples and components
+    2. Destroy infrastructure using Terraform
+
+    !!! danger "Destructive Operation"
+        This command removes all resources. Ensure you've backed up any data you need before running.
+
+## Verification
+
+After setup, verify your deployment:
+
+```bash
+# Check cluster connectivity
+kubectl cluster-info
+
+# List all pods
+kubectl get pods --all-namespaces
+
+# Check services
+kubectl get svc --all-namespaces
+
+# Check ingress endpoints
+kubectl get ingress --all-namespaces
+```
+
+## Next Steps
+
+- Review [Infrastructure Setup](infrastructure.md) for details on provisioned resources
+- Follow the [Demo Walkthrough](demo-walkthrough.md) to explore features
+- Check the [FAQs](../reference/faq.md) for common questions and troubleshooting

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,102 @@
+# GenAI on EKS Starter Kit
+
+A starter kit for deploying and managing GenAI components and examples on **Amazon EKS** (Elastic Kubernetes Service). This project provides a collection of tools, configurations, components, and examples to help you quickly set up a GenAI project on Kubernetes.
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Quick Start**
+
+    ---
+
+    Get up and running in minutes with the demo setup
+
+    [:octicons-arrow-right-24: Getting Started](getting-started/quick-start.md)
+
+-   :material-puzzle:{ .lg .middle } **Components**
+
+    ---
+
+    Browse 25+ deployable components across 10 categories
+
+    [:octicons-arrow-right-24: Components](components/index.md)
+
+-   :material-code-braces:{ .lg .middle } **Examples**
+
+    ---
+
+    Explore AI agents, MCP servers, and more
+
+    [:octicons-arrow-right-24: Examples](examples/index.md)
+
+-   :material-book-open:{ .lg .middle } **Reference**
+
+    ---
+
+    CLI commands, configuration, FAQ, and security
+
+    [:octicons-arrow-right-24: Reference](reference/cli-commands.md)
+
+</div>
+
+## What's Included
+
+| Category | Components |
+|----------|-----------|
+| **NVIDIA Platform** | GPU Operator, Monitoring, Dynamo Platform, Dynamo vLLM, AIPerf Benchmark, AIConfigurator |
+| **AI Gateway** | [LiteLLM](https://www.litellm.ai), [Kong AI Gateway](https://github.com/Kong/kong) |
+| **LLM Model** | [vLLM](https://docs.vllm.ai), [SGLang](https://docs.sglang.ai), [TGI](https://huggingface.co/docs/text-generation-inference), [Ollama](https://ollama.com) |
+| **Embedding Model** | [Text Embedding Inference (TEI)](https://huggingface.co/docs/text-embeddings-inference) |
+| **Guardrail** | [Guardrails AI](https://www.guardrailsai.com) |
+| **Observability** | [Langfuse](https://langfuse.com), [MLflow](https://mlflow.org), [Phoenix](https://phoenix.arize.com) |
+| **GUI App** | [Open WebUI](https://docs.openwebui.com) |
+| **Vector Database** | [Qdrant](https://qdrant.tech), [Chroma](https://docs.trychroma.com), [Milvus](https://milvus.io) |
+| **Workflow Automation** | [n8n](https://docs.n8n.io) |
+| **AI Agent** | [OpenClaw](https://github.com/openclaw/openclaw) |
+
+## Architecture Overview
+
+```mermaid
+graph TB
+    subgraph EKS["Amazon EKS Cluster"]
+        subgraph Gateway["AI Gateway"]
+            LiteLLM
+            Kong
+        end
+        subgraph Models["LLM / Embedding Models"]
+            vLLM
+            SGLang
+            TGI
+            Ollama
+            TEI
+        end
+        subgraph Apps["Applications"]
+            OpenWebUI["Open WebUI"]
+            n8n
+            OpenClaw
+        end
+        subgraph Observability
+            Langfuse
+            Phoenix
+            MLflow
+        end
+        subgraph Storage["Vector Databases"]
+            Qdrant
+            Chroma
+            Milvus
+        end
+        subgraph NVIDIA["NVIDIA Platform"]
+            Dynamo["Dynamo Platform"]
+            GPUOp["GPU Operator"]
+        end
+    end
+    OpenWebUI --> Gateway
+    Gateway --> Models
+    Gateway --> Langfuse
+    Models --> NVIDIA
+    Apps --> Gateway
+```
+
+## Disclaimer
+
+!!! warning
+    This repository is intended for **demonstration and learning purposes only**. It is not intended for production use. The code provided here is for educational purposes and should not be used in a live environment without proper testing, validation, and modifications.

--- a/docs/reference/cli-commands.md
+++ b/docs/reference/cli-commands.md
@@ -1,0 +1,494 @@
+# CLI Commands Reference
+
+The starter kit provides a unified CLI (`./cli`) for managing infrastructure, components, and examples. This page documents all available commands and their usage.
+
+## Core Commands
+
+### configure
+
+Configure environment variables for the project.
+
+```bash
+./cli configure
+```
+
+Interactive prompts for:
+
+- `REGION` - AWS region (e.g., `us-west-2`)
+- `EKS_CLUSTER_NAME` - Name of the EKS cluster
+- `EKS_MODE` - EKS mode: `auto` (default) or `standard`
+- `DOMAIN` - Domain name for ingress (optional)
+- `HF_TOKEN` - Hugging Face user access token
+
+Values are saved to `.env.local`.
+
+**Example:**
+```bash
+./cli configure
+# ✔ Enter value for REGION: us-west-2
+# ✔ Enter value for EKS_CLUSTER_NAME: genai-on-eks
+# ✔ Enter value for DOMAIN: example.com
+```
+
+---
+
+### demo-setup
+
+Quick setup with infrastructure and curated demo components.
+
+```bash
+./cli demo-setup
+```
+
+This command:
+
+1. Sets up required infrastructure using Terraform
+2. Deploys demo components specified in `config.json`
+3. Installs components in the correct dependency order
+
+See [Demo Walkthrough](../getting-started/demo-walkthrough.md) for details.
+
+---
+
+### interactive-setup
+
+Guided setup with component selection.
+
+```bash
+./cli interactive-setup
+```
+
+This command:
+
+1. Presents interactive menus for component selection
+2. Sets up required infrastructure using Terraform
+3. Installs selected components (order not guaranteed)
+
+**Example:**
+```bash
+./cli interactive-setup
+# ✔ Select AI Gateway components to install: litellm
+# ✔ Select LLM Model components to install: vllm
+# ✔ Select Embedding Model components to install: tei
+```
+
+!!! note
+    Some components may need to be re-installed after initial setup due to dependencies.
+
+---
+
+## Component Management
+
+### Install a Component
+
+```bash
+./cli <category> <component> install
+```
+
+**Categories:**
+- `nvidia-platform` - NVIDIA Platform components
+- `ai-gateway` - AI Gateway components
+- `llm-model` - LLM Model components
+- `embedding-model` - Embedding Model components
+- `guardrail` - Guardrail components
+- `o11y` - Observability components
+- `gui-app` - GUI App components
+- `vector-database` - Vector Database components
+- `workflow-automation` - Workflow Automation components
+- `ai-agent` - AI Agent components
+
+**Examples:**
+```bash
+./cli ai-gateway litellm install
+./cli llm-model vllm install
+./cli embedding-model tei install
+./cli o11y langfuse install
+./cli gui-app openwebui install
+./cli vector-database qdrant install
+./cli ai-agent openclaw install
+```
+
+---
+
+### Uninstall a Component
+
+```bash
+./cli <category> <component> uninstall
+```
+
+**Examples:**
+```bash
+./cli ai-gateway litellm uninstall
+./cli llm-model vllm uninstall
+./cli embedding-model tei uninstall
+```
+
+---
+
+## Example Management
+
+### Install an Example
+
+```bash
+./cli <category> <example> install
+```
+
+**Categories:**
+- `mcp-server` - MCP Server examples
+- `strands-agents` - Strands Agents examples
+- `agno` - Agno examples
+- `openclaw` - OpenClaw examples
+
+**Examples:**
+```bash
+./cli mcp-server calculator install
+./cli strands-agents calculator-agent install
+./cli agno calculator-agent install
+./cli openclaw doc-writer install
+./cli openclaw devops-agent install
+```
+
+---
+
+### Uninstall an Example
+
+```bash
+./cli <category> <example> uninstall
+```
+
+**Examples:**
+```bash
+./cli mcp-server calculator uninstall
+./cli strands-agents calculator-agent uninstall
+./cli agno calculator-agent uninstall
+./cli openclaw doc-writer uninstall
+./cli openclaw devops-agent uninstall
+```
+
+---
+
+## Model Management
+
+### Configure Models
+
+Configure which models should be deployed for a component.
+
+```bash
+./cli llm-model <component> configure-models
+./cli embedding-model <component> configure-models
+```
+
+**Examples:**
+```bash
+./cli llm-model vllm configure-models
+./cli llm-model sglang configure-models
+./cli embedding-model tei configure-models
+```
+
+This command presents an interactive menu to select models from the available list in `config.json`.
+
+---
+
+### Update Models
+
+Add and/or remove models for a component.
+
+```bash
+./cli llm-model <component> update-models
+./cli embedding-model <component> update-models
+```
+
+**Examples:**
+```bash
+./cli llm-model vllm update-models
+./cli embedding-model tei update-models
+```
+
+Interactive prompts:
+1. Select models to add (from available models)
+2. Select models to remove (from currently deployed models)
+
+---
+
+### Add Models
+
+Add missing models without removing existing ones.
+
+```bash
+./cli llm-model <component> add-models
+./cli embedding-model <component> add-models
+```
+
+**Examples:**
+```bash
+./cli llm-model vllm add-models
+./cli embedding-model tei add-models
+```
+
+This only adds new models - existing deployments are not touched.
+
+---
+
+### Remove All Models
+
+Remove all deployed models for a component.
+
+```bash
+./cli llm-model <component> remove-all-models
+./cli embedding-model <component> remove-all-models
+```
+
+**Examples:**
+```bash
+./cli llm-model vllm remove-all-models
+./cli embedding-model tei remove-all-models
+```
+
+!!! warning
+    This will delete all model deployments for the specified component.
+
+---
+
+## NVIDIA Platform Commands
+
+### Install NVIDIA Components
+
+```bash
+./cli nvidia-platform monitoring install          # Prometheus + Grafana
+./cli nvidia-platform gpu-operator install        # NVIDIA GPU Operator
+./cli nvidia-platform dynamo-platform install     # Dynamo CRDs, Operator, etcd, NATS
+./cli nvidia-platform dynamo-vllm install         # Deploy model with vLLM
+./cli nvidia-platform benchmark install           # AIPerf concurrency sweep
+./cli nvidia-platform aiconfigurator install      # TP/PP recommendation + SLA deploy
+```
+
+See [NVIDIA Platform Overview](../components/nvidia-platform/index.md) for detailed documentation.
+
+---
+
+## Cleanup Commands
+
+### cleanup-infra
+
+Destroy infrastructure using Terraform.
+
+```bash
+./cli cleanup-infra
+```
+
+This command:
+
+1. Runs `terraform destroy` to remove all AWS resources
+2. Keeps component/example deployments (if any remain)
+
+!!! warning
+    This will destroy the EKS cluster and all associated AWS resources.
+
+---
+
+### cleanup-everything
+
+Comprehensive cleanup of components, examples, and infrastructure.
+
+```bash
+./cli cleanup-everything
+```
+
+This command:
+
+1. Attempts to uninstall all deployed examples
+2. Attempts to uninstall all deployed components
+3. Destroys infrastructure using Terraform
+
+!!! warning
+    This is a destructive operation. Ensure you have backups of any important data.
+
+---
+
+## Terraform Commands
+
+### terraform apply
+
+Apply Terraform configuration.
+
+```bash
+./cli terraform apply
+```
+
+This command:
+
+1. Initializes Terraform workspace based on `EKS_CLUSTER_NAME`
+2. Runs `terraform apply` with auto-approve
+3. Applies infrastructure changes
+
+**Use cases:**
+- Update infrastructure after changing Terraform variables
+- Apply configuration changes from `config.json`
+- Re-apply infrastructure after manual modifications
+
+**Example:**
+```bash
+# Update ECR Pull Through Cache settings
+# Edit config.local.json to enable ECR Pull Through Cache
+./cli terraform apply
+```
+
+---
+
+## Command Options
+
+### Common Patterns
+
+All component/example commands follow the pattern:
+```bash
+./cli <category> <component|example> <action>
+```
+
+Where:
+- `<category>` - Component or example category
+- `<component|example>` - Specific component or example name
+- `<action>` - `install` or `uninstall`
+
+### Finding Available Components
+
+List all available components and examples in `cli-menu.json`:
+
+```bash
+cat cli-menu.json | jq '.componentCategories[].components[].name'
+cat cli-menu.json | jq '.exampleCategories[].examples[].name'
+```
+
+---
+
+## Environment Variables
+
+The CLI uses environment variables from:
+
+1. `.env` (default values)
+2. `config.json` (default configuration)
+3. `.env.local` (user overrides)
+4. `config.local.json` (user configuration)
+
+Later sources override earlier ones.
+
+### Key Variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `REGION` | AWS region | `us-west-2` |
+| `EKS_CLUSTER_NAME` | EKS cluster name | `genai-on-eks` |
+| `EKS_MODE` | EKS mode | `auto` |
+| `DOMAIN` | Domain name for ingress | _(empty)_ |
+| `HF_TOKEN` | Hugging Face token | _(required)_ |
+| `LITELLM_API_KEY` | LiteLLM API key | _(generated)_ |
+| `OPENCLAW_GATEWAY_TOKEN` | OpenClaw token | `openclaw-gateway-token` |
+
+---
+
+## Troubleshooting
+
+### Command Not Found
+
+**Problem:** `./cli: command not found`
+
+**Solution:** Ensure you're in the project root directory:
+```bash
+cd /path/to/sample-genai-on-eks-starter-kit
+./cli configure
+```
+
+### Permission Denied
+
+**Problem:** `./cli: Permission denied`
+
+**Solution:** Make the CLI executable:
+```bash
+chmod +x ./cli
+./cli configure
+```
+
+### Component Installation Fails
+
+**Problem:** Component fails to install
+
+**Solution:**
+1. Check prerequisites are installed (kubectl, helm, docker)
+2. Verify AWS credentials are configured
+3. Check cluster is accessible: `kubectl get nodes`
+4. Review component logs: `kubectl logs -n <namespace> -l app=<component>`
+
+### Terraform Errors
+
+**Problem:** Terraform commands fail
+
+**Solution:**
+1. Ensure Terraform is installed: `terraform version`
+2. Check AWS credentials: `aws sts get-caller-identity`
+3. Review Terraform state: `cd terraform && terraform show`
+4. Clean and re-initialize: `cd terraform && rm -rf .terraform && terraform init`
+
+---
+
+## Examples
+
+### Complete Setup Flow
+
+```bash
+# 1. Configure environment
+./cli configure
+
+# 2. Deploy infrastructure and demo components
+./cli demo-setup
+
+# 3. Install additional components
+./cli o11y langfuse install
+./cli vector-database qdrant install
+
+# 4. Install examples
+./cli mcp-server calculator install
+./cli agno calculator-agent install
+
+# 5. Configure models
+./cli llm-model vllm add-models
+
+# 6. Access services
+kubectl get ingress --all-namespaces
+```
+
+### Selective Installation
+
+```bash
+# Infrastructure only
+./cli terraform apply
+
+# Core components
+./cli ai-gateway litellm install
+./cli llm-model vllm install
+./cli gui-app openwebui install
+
+# Configure models
+./cli llm-model vllm configure-models
+
+# Install specific examples
+./cli openclaw doc-writer install
+```
+
+### Cleanup
+
+```bash
+# Remove specific components
+./cli llm-model vllm uninstall
+./cli ai-gateway litellm uninstall
+
+# Complete cleanup
+./cli cleanup-everything
+```
+
+---
+
+## See Also
+
+- [Configuration Guide](configuration.md)
+- [FAQ](faq.md)
+- [Demo Walkthrough](../getting-started/demo-walkthrough.md)
+- [Infrastructure Setup](../getting-started/infrastructure.md)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,0 +1,713 @@
+# Configuration Guide
+
+This guide explains how to configure the GenAI on EKS Starter Kit, including environment variables, configuration files, and advanced settings.
+
+## Configuration Hierarchy
+
+Configuration files are loaded in order, with later sources overriding earlier ones:
+
+```
+.env → config.json → .env.local → config.local.json
+```
+
+- **`.env`** - Default environment variables (tracked in git)
+- **`config.json`** - Default component configuration (tracked in git)
+- **`.env.local`** - User-specific environment overrides (gitignored)
+- **`config.local.json`** - User-specific configuration overrides (gitignored)
+
+!!! tip
+    Always use `.env.local` and `config.local.json` for your customizations. Never commit these files to version control.
+
+---
+
+## Environment Variables
+
+### Core Variables
+
+#### REGION
+
+AWS region for infrastructure deployment.
+
+```bash
+REGION=us-west-2
+```
+
+**Default:** `us-west-2`
+
+**Common values:**
+- `us-west-2` - Oregon (default)
+- `us-east-1` - N. Virginia
+- `eu-west-1` - Ireland
+- `ap-northeast-1` - Tokyo
+
+---
+
+#### EKS_CLUSTER_NAME
+
+Name of the EKS cluster.
+
+```bash
+EKS_CLUSTER_NAME=genai-on-eks
+```
+
+**Default:** `genai-on-eks`
+
+This value is used for:
+- EKS cluster name
+- Terraform workspace name
+- kubectl context selection
+
+---
+
+#### EKS_MODE
+
+EKS deployment mode.
+
+```bash
+EKS_MODE=auto
+```
+
+**Options:**
+- `auto` - EKS Auto Mode (default) - fully managed nodes
+- `standard` - Standard EKS with self-managed Karpenter
+
+**Auto Mode Benefits:**
+- Fully managed node lifecycle
+- Automatic scaling
+- Built-in best practices
+- Lower operational overhead
+
+---
+
+#### DOMAIN
+
+Domain name for ingress with Route 53 hosted zone.
+
+```bash
+DOMAIN=example.com
+```
+
+**Default:** _(empty)_
+
+**With domain:**
+- Single shared ALB with HTTPS
+- Wildcard ACM certificate
+- Route 53 DNS records
+- Services accessible at `<service>.<DOMAIN>` (e.g., `litellm.example.com`)
+
+**Without domain:**
+- Multiple ALBs with HTTP
+- No DNS records
+- Only one service with Nginx basic auth can be exposed
+
+---
+
+#### HF_TOKEN
+
+Hugging Face user access token.
+
+```bash
+HF_TOKEN=hf_your_token_here
+```
+
+**Required for:**
+- Downloading gated models (e.g., Llama, Mistral)
+- Text Embedding Inference (TEI)
+- Some vLLM/SGLang models
+
+**How to get:**
+1. Create account at [huggingface.co](https://huggingface.co)
+2. Go to [Settings → Access Tokens](https://huggingface.co/settings/tokens)
+3. Create a new token with `read` access
+
+---
+
+### Service API Keys
+
+#### LITELLM_API_KEY
+
+API key for accessing LiteLLM proxy.
+
+```bash
+LITELLM_API_KEY=sk-1234567890abcdef
+```
+
+**Default:** Auto-generated random string
+
+Used by:
+- AI agents to authenticate with LiteLLM
+- Examples (calculator agents, OpenClaw)
+- Open WebUI for model access
+
+---
+
+#### OPENCLAW_GATEWAY_TOKEN
+
+Authentication token for OpenClaw bridge server.
+
+```bash
+OPENCLAW_GATEWAY_TOKEN=openclaw-gateway-token
+```
+
+**Default:** `openclaw-gateway-token`
+
+Used by OpenClaw agents (doc-writer, devops-agent) to authenticate with the bridge server.
+
+---
+
+### Git Credentials (Optional)
+
+#### OpenClaw Document Writer
+
+```bash
+OPENCLAW_DOC_WRITER_GIT_USERNAME=your-github-username
+OPENCLAW_DOC_WRITER_GIT_TOKEN=ghp_your_fine_grained_token
+```
+
+**Purpose:** Allow doc-writer agent to push commits
+
+**Security:** Use fine-grained tokens with minimal permissions
+
+See [Document Writer Security](../examples/openclaw/doc-writer.md#git-credentials-optional) for details.
+
+---
+
+### Observability (Optional)
+
+#### Langfuse
+
+```bash
+LANGFUSE_PUBLIC_KEY=pk-lf-xxx
+LANGFUSE_SECRET_KEY=sk-lf-xxx
+LANGFUSE_HOST=https://langfuse.example.com
+```
+
+**Purpose:** Enable LLM observability and tracing
+
+**Auto-detected:** If Langfuse is installed, `LANGFUSE_HOST` is automatically set to the service URL
+
+---
+
+## config.json Structure
+
+The `config.json` file configures components, models, and infrastructure settings.
+
+### Component Configuration
+
+```json
+{
+  "components": {
+    "litellm": {
+      "replicas": 2,
+      "env": {
+        "DATABASE_URL": "postgresql://...",
+        "STORE_MODEL_IN_DB": "True"
+      },
+      "resources": {
+        "requests": { "cpu": "500m", "memory": "512Mi" },
+        "limits": { "cpu": "2000m", "memory": "2Gi" }
+      }
+    }
+  }
+}
+```
+
+---
+
+### Model Configuration
+
+#### LLM Models
+
+```json
+{
+  "components": {
+    "llm-model": {
+      "vllm": {
+        "models": [
+          {
+            "name": "llama-3.1-8b-instruct",
+            "huggingFaceId": "meta-llama/Llama-3.1-8B-Instruct",
+            "instanceFamily": "g6e",
+            "replicas": 1,
+            "env": {
+              "MAX_MODEL_LEN": "8192",
+              "GPU_MEMORY_UTILIZATION": "0.9"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**Fields:**
+- `name` - Model deployment name (used in URLs)
+- `huggingFaceId` - Hugging Face model repository
+- `instanceFamily` - EC2 instance family (`g6e`, `g6`, `g5`, etc.)
+- `replicas` - Number of replicas
+- `env` - vLLM environment variables
+
+---
+
+#### Embedding Models
+
+```json
+{
+  "components": {
+    "embedding-model": {
+      "tei": {
+        "models": [
+          {
+            "name": "gte-large-en-v1.5",
+            "huggingFaceId": "Alibaba-NLP/gte-large-en-v1.5",
+            "instanceFamily": "g6e",
+            "replicas": 1
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+---
+
+#### Bedrock Models
+
+```json
+{
+  "bedrock": {
+    "llm": {
+      "models": [
+        {
+          "name": "amazon-nova-premier",
+          "model": "us.amazon.nova-premier-v1:0"
+        },
+        {
+          "name": "claude-4-opus",
+          "model": "us.anthropic.claude-opus-4-20250514-v1:0"
+        }
+      ]
+    }
+  }
+}
+```
+
+**Fields:**
+- `name` - Friendly name for LiteLLM
+- `model` - Bedrock model ID
+
+---
+
+### Docker Build Settings
+
+```json
+{
+  "docker": {
+    "useBuildx": true,
+    "arch": "linux/amd64,linux/arm64"
+  }
+}
+```
+
+**Options:**
+- `useBuildx: true` - Multi-arch builds using Docker Buildx
+- `useBuildx: false` - Single-arch builds (native)
+- `arch` - Target architectures
+
+**Disable multi-arch:**
+```json
+{
+  "docker": {
+    "useBuildx": false,
+    "arch": "linux/amd64"
+  }
+}
+```
+
+---
+
+### Bedrock Region Configuration
+
+```json
+{
+  "bedrock": {
+    "region": "us-west-2"
+  }
+}
+```
+
+**Default:** Uses the same region as `REGION` environment variable
+
+**Use case:** Access Bedrock models in a different region than your EKS cluster
+
+---
+
+### Neuron Support
+
+Enable AWS Neuron for Inferentia 2 instances.
+
+```json
+{
+  "components": {
+    "llm-model": {
+      "vllm": {
+        "enableNeuron": true,
+        "models": [
+          {
+            "name": "llama-3.1-8b-instruct-neuron",
+            "huggingFaceId": "meta-llama/Llama-3.1-8B-Instruct",
+            "instanceFamily": "inf2",
+            "neuron": {
+              "tensorParallelSize": 8,
+              "compile": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**Fields:**
+- `enableNeuron: true` - Enable Neuron support (builds vLLM Neuron image)
+- `neuron.tensorParallelSize` - Number of Neuron cores
+- `neuron.compile: true` - Compile model on first run (requires inf2.8xlarge)
+- `neuron.compile: false` - Use cached compilation (can use inf2.xlarge)
+
+**Process:**
+1. Set `enableNeuron: true` and `compile: true`
+2. Deploy model (uses inf2.8xlarge for compilation)
+3. Wait for compilation to complete (~20-30 mins)
+4. Set `compile: false` to use cached model
+5. Redeploy (can use smaller instance like inf2.xlarge for INT8 quantized models)
+
+---
+
+## ECR Pull Through Cache
+
+ECR Pull Through Cache caches external container images in your private ECR registry to avoid rate limits.
+
+### Configuration
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "enable_ecr_pull_through_cache": true,
+      "dockerhub_username": "your-dockerhub-username",
+      "dockerhub_access_token": "dckr_pat_xxx",
+      "github_username": "your-github-username",
+      "github_token": "ghp_xxx"
+    }
+  }
+}
+```
+
+!!! warning
+    Always use `config.local.json` for credentials, never commit to `config.json`.
+
+### Why Disabled by Default?
+
+- **Storage costs**: Cached images are stored in private ECR
+- **Public registries work fine**: EKS nodes have internet access
+- **Most use cases don't need it**: Rate limits rarely hit in typical usage
+
+### When to Enable
+
+- Hitting Docker Hub rate limits (100 pulls/6hrs anonymous, 200 pulls/6hrs authenticated)
+- Need faster, more reliable pulls from within AWS
+- Organization requires images in private registries
+- Air-gapped or restricted network environments
+
+### Getting Credentials
+
+**Docker Hub:**
+1. Create account at [hub.docker.com](https://hub.docker.com)
+2. Go to [Security Settings](https://hub.docker.com/settings/security)
+3. Click "New Access Token"
+4. Copy username and token
+
+**GitHub:**
+1. Go to [Settings → Developer settings → Personal access tokens](https://github.com/settings/tokens)
+2. Generate new token (classic)
+3. Select `read:packages` scope
+4. Copy username and token
+
+### Supported Registries
+
+- `vllm/*` → Docker Hub
+- `lmsysorg/*` → Docker Hub
+- `ollama/*` → Docker Hub
+- `huggingface/*` → GitHub Container Registry
+
+### Cleanup
+
+When you run `terraform destroy`, cache rules are deleted but cached repositories remain.
+
+**Manual cleanup:**
+```bash
+aws ecr describe-repositories --region $REGION | \
+  jq -r '.repositories[] | select(.repositoryName | startswith("vllm/") or startswith("lmsysorg/") or startswith("ollama/") or startswith("huggingface/")) | .repositoryName' | \
+  xargs -I {} aws ecr delete-repository --repository-name {} --force --region $REGION
+```
+
+---
+
+## Terraform Variables
+
+Advanced Terraform configuration in `config.json`:
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "enable_ecr_pull_through_cache": false,
+      "instance_families": ["g6e", "g6", "g5"],
+      "purchasing_options": ["spot", "on-demand"]
+    }
+  }
+}
+```
+
+### Instance Families
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "instance_families": ["g6e", "g6", "g5", "p5", "p4d"]
+    }
+  }
+}
+```
+
+**Default:** `["g6e", "g6", "g5"]`
+
+**Common families:**
+- `g6e` - NVIDIA L40S (newest, best price/performance)
+- `g6` - NVIDIA L4
+- `g5` - NVIDIA A10G
+- `p5` - NVIDIA H100 (highest performance)
+- `p4d` - NVIDIA A100
+- `inf2` - AWS Inferentia 2 (Neuron)
+
+---
+
+### Purchasing Options
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "purchasing_options": ["spot", "on-demand"]
+    }
+  }
+}
+```
+
+**Default:** `["spot", "on-demand"]`
+
+**Options:**
+- `spot` - Up to 90% savings, can be interrupted
+- `on-demand` - Stable, no interruptions
+
+---
+
+## Configuration Examples
+
+### Development Environment
+
+```json
+{
+  "docker": {
+    "useBuildx": false,
+    "arch": "linux/amd64"
+  },
+  "components": {
+    "litellm": {
+      "replicas": 1
+    },
+    "llm-model": {
+      "vllm": {
+        "models": [
+          {
+            "name": "llama-3.1-8b-instruct",
+            "replicas": 1
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**Features:**
+- Single-arch builds (faster)
+- Minimal replicas (lower cost)
+- Small models only
+
+---
+
+### Production Environment
+
+```json
+{
+  "docker": {
+    "useBuildx": true,
+    "arch": "linux/amd64,linux/arm64"
+  },
+  "components": {
+    "litellm": {
+      "replicas": 3,
+      "env": {
+        "DATABASE_URL": "postgresql://...",
+        "STORE_MODEL_IN_DB": "True"
+      }
+    },
+    "llm-model": {
+      "vllm": {
+        "models": [
+          {
+            "name": "llama-3.1-70b-instruct",
+            "replicas": 2
+          }
+        ]
+      }
+    }
+  },
+  "terraform": {
+    "vars": {
+      "enable_ecr_pull_through_cache": true,
+      "purchasing_options": ["on-demand"]
+    }
+  }
+}
+```
+
+**Features:**
+- Multi-arch builds (flexibility)
+- High availability (multiple replicas)
+- ECR Pull Through Cache (reliability)
+- On-demand instances (stability)
+- Database persistence
+
+---
+
+### Cost-Optimized Environment
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "purchasing_options": ["spot"],
+      "instance_families": ["g6e"]
+    }
+  },
+  "components": {
+    "llm-model": {
+      "vllm": {
+        "models": [
+          {
+            "name": "llama-3.1-8b-instruct",
+            "instanceFamily": "g6e",
+            "replicas": 1,
+            "env": {
+              "GPU_MEMORY_UTILIZATION": "0.95"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+**Features:**
+- Spot instances only (up to 90% savings)
+- Latest instance family (g6e - best price/performance)
+- Small models
+- High GPU utilization
+
+---
+
+## Security Best Practices
+
+### Environment Variables
+
+✅ **DO:**
+- Use `.env.local` for sensitive values
+- Generate strong random API keys
+- Rotate credentials regularly
+- Use fine-grained tokens with minimal permissions
+
+❌ **DON'T:**
+- Commit `.env.local` or `config.local.json` to git
+- Use classic GitHub tokens (use fine-grained)
+- Share API keys across environments
+- Hardcode credentials in code
+
+---
+
+### Configuration Files
+
+✅ **DO:**
+- Keep `config.json` for defaults only
+- Use `config.local.json` for overrides
+- Document required environment variables
+- Validate configuration on startup
+
+❌ **DON'T:**
+- Store credentials in `config.json`
+- Commit `config.local.json` to git
+- Use weak passwords or tokens
+
+---
+
+## Troubleshooting
+
+### Configuration Not Loading
+
+**Problem:** Changes to config files not taking effect
+
+**Solution:**
+1. Verify file names (`.env.local`, not `.env.local.txt`)
+2. Check JSON syntax: `jq . config.local.json`
+3. Restart component: `./cli <category> <component> install`
+
+---
+
+### Environment Variable Precedence
+
+**Problem:** Wrong environment variable value used
+
+**Solution:** Check loading order:
+```bash
+# Check effective configuration
+cat .env
+cat .env.local
+echo $REGION
+```
+
+---
+
+### Model Not Loading
+
+**Problem:** Model fails to deploy
+
+**Solution:**
+1. Verify `huggingFaceId` is correct
+2. Check `HF_TOKEN` is set for gated models
+3. Ensure instance family has sufficient GPU memory
+4. Review pod logs: `kubectl logs -n vllm -l model=<name>`
+
+---
+
+## See Also
+
+- [CLI Commands Reference](cli-commands.md)
+- [FAQ](faq.md)
+- [Security Considerations](security.md)
+- [Infrastructure Setup](../getting-started/infrastructure.md)

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -1,0 +1,543 @@
+# Frequently Asked Questions (FAQ)
+
+Common questions and answers about the GenAI on EKS Starter Kit.
+
+---
+
+## Configuration
+
+### How do the config files work?
+
+`.env` and `config.json` are loaded first as defaults. Then, the configuration is merged/overridden with values from `.env.local` and `config.local.json` if they exist.
+
+**Loading order:**
+```
+.env → config.json → .env.local → config.local.json
+```
+
+**Best practice:**
+- Keep defaults in `.env` and `config.json` (tracked in git)
+- Keep your customizations in `.env.local` and `config.local.json` (gitignored)
+
+**Example:**
+```bash
+# .env (default)
+REGION=us-west-2
+
+# .env.local (your override)
+REGION=us-east-1
+```
+
+The final value will be `us-east-1`.
+
+---
+
+## Domain & Networking
+
+### How can I use this starter kit without having a Route 53 hosted zone?
+
+There are two ingress configurations:
+
+**With a domain (recommended):**
+- Single shared ALB with HTTPS
+- Wildcard ACM certificate
+- Route 53 DNS records
+- All services accessible at `<service>.<DOMAIN>`
+- Example: `litellm.example.com`, `openwebui.example.com`
+
+**Without a domain:**
+- Multiple ALBs with HTTP
+- No DNS records required
+- Only one service requiring Nginx Ingress basic auth (e.g., Milvus, Qdrant) can be exposed
+- Access services via ALB DNS names (long URLs)
+
+**To use without a domain:**
+
+1. Leave `DOMAIN` empty in `.env`:
+   ```bash
+   DOMAIN=
+   ```
+
+2. Each public-facing service will get its own ALB
+
+3. Find service URLs:
+   ```bash
+   kubectl get ingress --all-namespaces
+   ```
+
+**Limitations without domain:**
+- Cannot expose multiple services with basic auth
+- HTTP only (no HTTPS)
+- Long ALB DNS names instead of friendly URLs
+
+---
+
+## Model Management
+
+### How can I configure and update the LiteLLM proxy model list?
+
+LiteLLM automatically discovers self-hosted models (vLLM, SGLang, Ollama, TGI) running in the cluster.
+
+For **Bedrock models**, the model list is configured in `config.json`:
+
+```json
+{
+  "bedrock": {
+    "llm": {
+      "models": [
+        {
+          "name": "amazon-nova-premier",
+          "model": "us.amazon.nova-premier-v1:0"
+        },
+        {
+          "name": "claude-4-opus",
+          "model": "us.anthropic.claude-opus-4-20250514-v1:0"
+        }
+      ]
+    }
+  }
+}
+```
+
+**To update:**
+
+1. Edit `config.json` or `config.local.json` (recommended)
+2. Reinstall LiteLLM:
+   ```bash
+   ./cli ai-gateway litellm install
+   ```
+
+**Self-hosted models:**
+
+Self-hosted models are automatically detected from running pods and added to LiteLLM's config.
+
+To add a new model:
+```bash
+./cli llm-model vllm add-models
+```
+
+To update models:
+```bash
+./cli llm-model vllm update-models
+```
+
+---
+
+## Infrastructure
+
+### How can I change the EC2 GPU instance families and purchasing options?
+
+The default instance families are `g6e`, `g6`, and `g5`. The default purchasing options are `spot` and `on-demand`.
+
+**To change:**
+
+1. Edit `terraform/0-common.tf` directly, OR
+2. Edit `config.json` or `config.local.json`:
+
+```json
+{
+  "terraform": {
+    "vars": {
+      "instance_families": ["g6e", "p5", "p4d"],
+      "purchasing_options": ["on-demand"]
+    }
+  }
+}
+```
+
+3. Apply the changes:
+```bash
+./cli terraform apply
+```
+
+**Note:** Model deployment manifests use `nodeSelector` to lock to specific instance families:
+
+```yaml
+nodeSelector:
+  eks.amazonaws.com/instance-family: g6e
+```
+
+You'll need to adjust the `instanceFamily` field in model configurations accordingly.
+
+**Common instance families:**
+- `g6e` - NVIDIA L40S (newest, best price/performance)
+- `g6` - NVIDIA L4
+- `g5` - NVIDIA A10G
+- `p5` - NVIDIA H100 (highest performance)
+- `p4d` - NVIDIA A100
+- `inf2` - AWS Inferentia 2 (for Neuron)
+
+---
+
+## Neuron & Inferentia
+
+### How can I use LLM models with AWS Neuron and EC2 Inferentia 2?
+
+Supported models have the `-neuron` suffix. To enable Neuron support:
+
+1. Enable Neuron in `config.json` or `config.local.json`:
+```json
+{
+  "components": {
+    "llm-model": {
+      "vllm": {
+        "enableNeuron": true,
+        "models": [
+          {
+            "name": "llama-3.1-8b-instruct-neuron",
+            "huggingFaceId": "meta-llama/Llama-3.1-8B-Instruct",
+            "instanceFamily": "inf2",
+            "neuron": {
+              "tensorParallelSize": 8,
+              "compile": true
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+2. Install the component (builds vLLM Neuron image, takes ~20-30 mins):
+```bash
+./cli llm-model vllm install
+```
+
+**First-time deployment:**
+
+When a Neuron model is deployed for the first time, Neuron performs just-in-time (JIT) compilation which takes ~20-30 minutes. The compiled model is cached on EFS for subsequent deployments.
+
+**Using INT8 quantization on inf2.xlarge:**
+
+Models like Llama-3.1-8B-Instruct, DeepSeek-R1-Distill-Llama-8B, and Mistral-7B-Instruct-v0.3 support INT8 quantization to run on a single inf2.xlarge. However, compilation still requires inf2.8xlarge.
+
+**Process:**
+
+1. Deploy with `compile: true` (uses inf2.8xlarge for compilation):
+```json
+{
+  "neuron": {
+    "tensorParallelSize": 8,
+    "compile": true
+  }
+}
+```
+
+2. Wait for compilation to complete (~20-30 mins)
+
+3. Change to `compile: false` in config:
+```json
+{
+  "neuron": {
+    "tensorParallelSize": 8,
+    "compile": false
+  }
+}
+```
+
+4. Delete the model deployment:
+```bash
+kubectl delete deployment <model-name> -n vllm
+```
+
+5. Redeploy (now uses inf2.xlarge with cached model):
+```bash
+./cli llm-model vllm install
+```
+
+---
+
+## Docker & Multi-Arch
+
+### How can I disable the multi-arch container image build?
+
+By default, Docker Buildx is used to build multi-arch container images (`linux/amd64` and `linux/arm64`).
+
+**To disable:**
+
+1. Edit `config.json` or `config.local.json`:
+```json
+{
+  "docker": {
+    "useBuildx": false,
+    "arch": "linux/amd64"
+  }
+}
+```
+
+2. Set `arch` based on your machine's OS architecture:
+   - Intel/AMD Mac: `linux/amd64`
+   - M1/M2/M3 Mac: `linux/arm64`
+   - Intel/AMD Linux: `linux/amd64`
+   - ARM Linux: `linux/arm64`
+
+**When to disable:**
+- Faster builds during development
+- Don't need ARM64 support
+- Buildx not available
+
+**When to keep enabled:**
+- Production deployments
+- Need both AMD64 and ARM64 support
+- Using Karpenter with mixed instance types
+
+---
+
+## Bedrock
+
+### How can I use a different AWS region for Bedrock?
+
+By default, Bedrock uses the same region as your EKS cluster (`REGION` environment variable).
+
+**To use a different region:**
+
+1. Edit `config.json` or `config.local.json`:
+```json
+{
+  "bedrock": {
+    "region": "us-east-1"
+  }
+}
+```
+
+2. Reinstall LiteLLM:
+```bash
+./cli ai-gateway litellm install
+```
+
+**Use cases:**
+- Access models not available in your EKS region
+- Use Bedrock in a region with lower latency
+- Comply with data residency requirements
+
+**Example:**
+```json
+{
+  "bedrock": {
+    "region": "us-east-1",
+    "llm": {
+      "models": [
+        {
+          "name": "claude-4-opus",
+          "model": "us.anthropic.claude-opus-4-20250514-v1:0"
+        }
+      ]
+    }
+  }
+}
+```
+
+---
+
+## Multi-Cluster
+
+### How can I provision and manage multiple EKS clusters?
+
+You can manage multiple clusters by changing the values of `REGION`, `EKS_CLUSTER_NAME`, and `DOMAIN` in `.env` or `.env.local`.
+
+Terraform workspace and kubectl context automatically use these values when running `./cli` commands.
+
+**Example workflow:**
+
+1. Configure first cluster:
+```bash
+# .env.local
+REGION=us-west-2
+EKS_CLUSTER_NAME=genai-on-eks-west
+DOMAIN=west.example.com
+```
+
+2. Deploy first cluster:
+```bash
+./cli demo-setup
+```
+
+3. Configure second cluster:
+```bash
+# .env.local
+REGION=us-east-1
+EKS_CLUSTER_NAME=genai-on-eks-east
+DOMAIN=east.example.com
+```
+
+4. Deploy second cluster:
+```bash
+./cli demo-setup
+```
+
+**How it works:**
+
+- Terraform uses workspace named after `EKS_CLUSTER_NAME`
+- kubectl context is automatically selected based on cluster name
+- Each cluster has independent state
+
+**Switch between clusters:**
+
+```bash
+# Edit .env.local to change EKS_CLUSTER_NAME
+# All subsequent commands target the specified cluster
+./cli ai-gateway litellm install
+```
+
+---
+
+## ECR Pull Through Cache
+
+### What is ECR Pull Through Cache and should I enable it?
+
+ECR Pull Through Cache caches external container images (from Docker Hub, GitHub Container Registry) in your private ECR registry.
+
+**Benefits:**
+- Avoids rate limits from public registries
+- Faster pulls from within AWS
+- Images stay within your AWS infrastructure
+- More reliable (no external registry downtime)
+
+**Default: Disabled** (`enable_ecr_pull_through_cache = false`)
+
+**Why disabled by default?**
+- Cached images stored in ECR incur storage costs
+- Public registries work fine for most use cases (EKS nodes have internet access)
+- Requires Docker Hub and GitHub authentication
+
+**Rate limits:**
+- Docker Hub anonymous: 100 pulls/6 hours
+- Docker Hub authenticated: 200 pulls/6 hours
+- GitHub: Generally higher limits
+
+**When to enable:**
+- Hitting rate limits (frequent large-scale deployments)
+- Need faster, more reliable pulls
+- Organization requires private registry storage
+- Air-gapped or restricted network environments
+
+**To enable:**
+
+1. Get credentials:
+   - [Docker Hub access token](https://hub.docker.com/settings/security)
+   - [GitHub Personal Access Token](https://github.com/settings/tokens) with `read:packages`
+
+2. Add to `config.local.json`:
+```json
+{
+  "terraform": {
+    "vars": {
+      "enable_ecr_pull_through_cache": true,
+      "dockerhub_username": "your-dockerhub-username",
+      "dockerhub_access_token": "dckr_pat_xxx",
+      "github_username": "your-github-username",
+      "github_token": "ghp_xxx"
+    }
+  }
+}
+```
+
+3. Apply:
+```bash
+./cli terraform apply
+```
+
+**Supported registries:**
+- `vllm/*` → Docker Hub
+- `lmsysorg/*` → Docker Hub
+- `ollama/*` → Docker Hub
+- `huggingface/*` → GitHub Container Registry
+
+**Cleanup:**
+
+When you run `terraform destroy`, cache rules are deleted but cached repositories remain.
+
+Manual cleanup:
+```bash
+aws ecr describe-repositories --region $REGION | \
+  jq -r '.repositories[] | select(.repositoryName | startswith("vllm/") or startswith("lmsysorg/") or startswith("ollama/") or startswith("huggingface/")) | .repositoryName' | \
+  xargs -I {} aws ecr delete-repository --repository-name {} --force --region $REGION
+```
+
+---
+
+## Troubleshooting
+
+### Components fail to install
+
+**Problem:** `./cli <category> <component> install` fails
+
+**Common causes:**
+
+1. **Prerequisites not installed:**
+   - Check: `kubectl version`, `helm version`, `docker version`
+   - Solution: Install missing tools
+
+2. **Cluster not accessible:**
+   - Check: `kubectl get nodes`
+   - Solution: Run `aws eks update-kubeconfig --name $EKS_CLUSTER_NAME --region $REGION`
+
+3. **Dependencies not installed:**
+   - Some components depend on others (e.g., examples need LiteLLM)
+   - Solution: Install dependencies first
+
+4. **Resource limits:**
+   - Insufficient GPU nodes
+   - Solution: Check node availability: `kubectl get nodes -l eks.amazonaws.com/compute-type=gpu`
+
+---
+
+### Models fail to deploy
+
+**Problem:** Model pod stays in `Pending` or `ImagePullBackOff`
+
+**Solutions:**
+
+1. **Pending (no nodes):**
+   ```bash
+   kubectl describe pod -n vllm <pod-name>
+   # Check Events for "no nodes available"
+   ```
+   - Solution: Wait for Karpenter to provision nodes (~5 mins)
+   - Or check instance families are available in your region
+
+2. **ImagePullBackOff:**
+   ```bash
+   kubectl describe pod -n vllm <pod-name>
+   # Check Events for image pull errors
+   ```
+   - Solution: Verify HF_TOKEN is set for gated models
+   - Or check Docker Hub rate limits (enable ECR Pull Through Cache)
+
+3. **CrashLoopBackOff:**
+   ```bash
+   kubectl logs -n vllm <pod-name>
+   # Check logs for OOM or CUDA errors
+   ```
+   - Solution: Increase GPU memory utilization or use larger instance
+
+---
+
+### Services not accessible
+
+**Problem:** Cannot access services via ingress
+
+**Solutions:**
+
+1. **With domain:**
+   - Verify Route 53 hosted zone exists
+   - Check DNS records: `nslookup litellm.$DOMAIN`
+   - Check ALB: `kubectl get ingress -n litellm`
+
+2. **Without domain:**
+   - Find ALB DNS name: `kubectl get ingress --all-namespaces`
+   - Use ALB DNS name directly
+
+3. **Certificate issues:**
+   - Check ACM certificate status in AWS console
+   - Ensure DNS validation records exist
+
+---
+
+## See Also
+
+- [Configuration Guide](configuration.md)
+- [CLI Commands Reference](cli-commands.md)
+- [Security Considerations](security.md)
+- [Demo Walkthrough](../getting-started/demo-walkthrough.md)

--- a/docs/reference/security.md
+++ b/docs/reference/security.md
@@ -1,0 +1,552 @@
+# Security Considerations
+
+This page documents security considerations for the GenAI on EKS Starter Kit based on Checkov security scans. The project is designed for demonstration and learning purposes, prioritizing ease of experimentation over production-grade security.
+
+!!! warning "Demonstration Purpose"
+    This repository is intended for **demonstration and learning purposes only**. It is **not** intended for production use without proper security hardening, testing, and validation.
+
+---
+
+## Checkov Security Scans
+
+Our code is continuously scanned using [Checkov](https://www.checkov.io/5.Policy%20Index/kubernetes.html) to identify security considerations. Below are documented exceptions with explanations and recommendations for production deployments.
+
+---
+
+## Security Checks
+
+### CKV_TF_1: Terraform Module Source Commit Hash
+
+**Check:** Ensure Terraform module sources use a commit hash
+
+**Current Implementation:** We specify module versions instead of commit hashes for ease of experimentation.
+
+**Reasoning:** Version pinning provides a balance between stability and ease of updates during development and learning.
+
+**Production Recommendation:** Use commit hashes for Terraform modules to prevent supply chain attacks:
+
+```hcl
+# Development (current)
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.0.0"
+}
+
+# Production (recommended)
+module "vpc" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git?ref=abc123def456"
+}
+```
+
+**Why commit hashes matter:** Module registries can be compromised. Commit hashes provide immutable references. [Read more about supply chain vulnerabilities](https://medium.com/boostsecurity/erosion-of-trust-unmasking-supply-chain-vulnerabilities-in-the-terraform-registry-2af48a7eb2).
+
+---
+
+### CKV_SECRET_6: Base64 High Entropy String
+
+**Check:** Detects Base64-encoded, high-entropy strings
+
+**Current Implementation:** Kubernetes secrets contain Base64-encoded values (required by Kubernetes).
+
+**Reasoning:** All values under the `data` field in Kubernetes secrets must be Base64-encoded per Kubernetes specification. This is expected and correct behavior.
+
+**Impact:** This check produces expected false positives for all Kubernetes secret resources.
+
+**Production Recommendation:**
+- Store secrets outside version control
+- Use AWS Secrets Manager or HashiCorp Vault
+- Enable encryption at rest for secrets in etcd
+- Rotate secrets regularly
+
+```bash
+# Example: Store in AWS Secrets Manager instead of K8s Secret
+aws secretsmanager create-secret \
+  --name litellm-api-key \
+  --secret-string "sk-1234567890abcdef"
+```
+
+---
+
+### CKV2_K8S_6: Network Policy
+
+**Check:** Minimize admission of pods which lack an associated NetworkPolicy
+
+**Current Implementation:** All pod-to-pod communication is allowed by default.
+
+**Reasoning:** Simplifies experimentation and debugging by avoiding network connectivity issues during learning.
+
+**Production Recommendation:** Implement NetworkPolicies to segment traffic:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: litellm-netpol
+  namespace: litellm
+spec:
+  podSelector:
+    matchLabels:
+      app: litellm
+  policyTypes:
+  - Ingress
+  - Egress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: openwebui
+    ports:
+    - protocol: TCP
+      port: 4000
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: vllm
+    ports:
+    - protocol: TCP
+      port: 8000
+```
+
+Amazon VPC CNI supports [Kubernetes Network Policies](https://aws.amazon.com/blogs/containers/amazon-vpc-cni-now-supports-kubernetes-network-policies/).
+
+---
+
+### CKV_K8S_8: Liveness Probe
+
+**Check:** Liveness probe should be configured
+
+**Current Implementation:** No liveness probes configured.
+
+**Reasoning:** Simplifies deployment and avoids unnecessary pod restarts during experimentation.
+
+**Production Recommendation:** Implement health checks for automatic recovery:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /health
+    port: 8000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+```
+
+[Learn more about liveness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+---
+
+### CKV_K8S_9: Readiness Probe
+
+**Check:** Readiness probe should be configured
+
+**Current Implementation:** No readiness probes configured.
+
+**Reasoning:** Simplifies deployment and allows immediate traffic routing during experimentation.
+
+**Production Recommendation:** Implement readiness probes to prevent traffic to unhealthy pods:
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /v1/models
+    port: 8000
+  initialDelaySeconds: 10
+  periodSeconds: 5
+  timeoutSeconds: 3
+  successThreshold: 1
+  failureThreshold: 3
+```
+
+[Learn more about readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/).
+
+---
+
+### CKV_K8S_11: CPU Limits
+
+**Check:** CPU limits should be set
+
+**Current Implementation:** CPU limits not configured on containers.
+
+**Reasoning:** Allows maximum performance during model inference without artificial constraints.
+
+**Production Recommendation:** Set CPU limits to prevent resource exhaustion:
+
+```yaml
+resources:
+  requests:
+    cpu: "1000m"
+    memory: "2Gi"
+  limits:
+    cpu: "4000m"
+    memory: "4Gi"
+```
+
+**Considerations:**
+- GPU workloads are primarily memory-bound
+- CPU limits can cause throttling
+- Monitor actual usage before setting limits
+
+[Learn more about resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/).
+
+---
+
+### CKV_K8S_22: Read-Only Root Filesystem
+
+**Check:** Use read-only filesystem for containers where possible
+
+**Current Implementation:** Containers use read-write root filesystems.
+
+**Reasoning:** Some workloads require write access for model caching, temporary files, and runtime data.
+
+**Production Recommendation:** Enable read-only root filesystem where possible:
+
+```yaml
+securityContext:
+  readOnlyRootFilesystem: true
+volumeMounts:
+- name: tmp
+  mountPath: /tmp
+- name: cache
+  mountPath: /root/.cache
+volumes:
+- name: tmp
+  emptyDir: {}
+- name: cache
+  emptyDir: {}
+```
+
+[Configure read-only root filesystem](https://docs.aws.amazon.com/eks/latest/best-practices/pod-security.html#_configure_your_images_with_read_only_root_file_system).
+
+---
+
+### CKV_K8S_23: Non-Root Containers
+
+**Check:** Minimize the admission of root containers
+
+**Current Implementation:** Containers run as root (default).
+
+**Reasoning:** Ensures compatibility with demo images and simplifies troubleshooting during experimentation.
+
+**Production Recommendation:** Run containers as non-root user:
+
+```dockerfile
+# In Dockerfile
+RUN useradd -m -u 1000 appuser
+USER 1000:1000
+```
+
+```yaml
+# In Kubernetes manifest
+securityContext:
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+```
+
+[Learn more about non-root containers](https://docs.docker.com/engine/reference/builder/#user).
+
+---
+
+### CKV_K8S_35: Secrets as Files
+
+**Check:** Prefer using secrets as files over environment variables
+
+**Current Implementation:** Some secrets are passed as environment variables.
+
+**Reasoning:** Simplifies demonstration and reduces configuration complexity.
+
+**Production Recommendation:** Mount secrets as files instead of environment variables:
+
+```yaml
+# Instead of:
+env:
+- name: LITELLM_API_KEY
+  valueFrom:
+    secretKeyRef:
+      name: litellm-secret
+      key: api-key
+
+# Use:
+volumeMounts:
+- name: secrets
+  mountPath: /secrets
+  readOnly: true
+volumes:
+- name: secrets
+  secret:
+    secretName: litellm-secret
+```
+
+**Why files are better:**
+- Environment variables can leak in logs
+- Files have stricter access controls
+- Easier to rotate without restarting pods
+
+[Learn more about secret best practices](https://kubernetes.io/docs/concepts/configuration/secret/#best-practices).
+
+---
+
+### CKV_K8S_37: Container Capabilities
+
+**Check:** Minimize the admission of containers with capabilities assigned
+
+**Current Implementation:** Some workloads require added capabilities (e.g., GPU access, network administration).
+
+**Reasoning:** Required for GPU drivers and specialized hardware access.
+
+**Production Recommendation:** Use minimal required capabilities:
+
+```yaml
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+    add:
+    - NET_BIND_SERVICE  # Only if needed
+```
+
+[Learn more about Linux capabilities](https://docs.aws.amazon.com/eks/latest/best-practices/pod-security.html#_linux_capabilities).
+
+---
+
+### CKV_K8S_40: High UID
+
+**Check:** Containers should run as a high UID to avoid host conflict
+
+**Current Implementation:** Publicly available container images use default UIDs.
+
+**Reasoning:** Using upstream images as-is for easy access and reduced maintenance.
+
+**Production Recommendation:** Build custom images with high UID:
+
+```dockerfile
+RUN useradd -m -u 10000 appuser
+USER 10000:10000
+```
+
+```yaml
+securityContext:
+  runAsUser: 10000
+  runAsGroup: 10000
+```
+
+[Learn more about security contexts](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod).
+
+---
+
+### CKV_AWS_51: ECR Image Tag Immutability
+
+**Check:** Ensure ECR image tags are immutable
+
+**Current Implementation:** ECR repositories use mutable image tags.
+
+**Reasoning:** Allows easy updates and experimentation with container images during development.
+
+**Production Recommendation:** Enable image tag immutability:
+
+```hcl
+resource "aws_ecr_repository" "app" {
+  name                 = "my-app"
+  image_tag_mutability = "IMMUTABLE"
+}
+```
+
+**Benefits:**
+- Prevents accidental overwrites
+- Ensures deployment consistency
+- Supports rollback to exact previous versions
+
+[Learn more about image tag immutability](https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-tag-mutability.html).
+
+---
+
+### CKV_AWS_184: Customer-Managed KMS Keys
+
+**Check:** Ensure resources are encrypted with customer-managed KMS keys
+
+**Current Implementation:** Uses AWS managed keys for simplicity.
+
+**Reasoning:** Reduces setup complexity and key management overhead for demonstration purposes.
+
+**Production Recommendation:** Use customer-managed KMS keys:
+
+```hcl
+resource "aws_kms_key" "app" {
+  description             = "Application encryption key"
+  deletion_window_in_days = 7
+  enable_key_rotation     = true
+}
+
+resource "aws_ebs_volume" "app" {
+  kms_key_id = aws_kms_key.app.arn
+  encrypted  = true
+}
+```
+
+**Benefits:**
+- Enhanced security control
+- Audit key usage with CloudTrail
+- Meet compliance requirements
+- Control key rotation policy
+
+[Learn more about customer-managed keys](https://docs.aws.amazon.com/kms/latest/developerguide/concepts.html#customer-cmk).
+
+---
+
+### CKV_DOCKER_2: Dockerfile HEALTHCHECK
+
+**Check:** Ensure HEALTHCHECK instructions are added to container images
+
+**Current Implementation:** Container images lack explicit HEALTHCHECK instructions.
+
+**Reasoning:** Relies on Kubernetes liveness/readiness probes instead of Docker-layer health checks.
+
+**Production Recommendation:** Add HEALTHCHECK to Dockerfiles:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=3s --start-period=30s --retries=3 \
+  CMD curl -f http://localhost:8000/health || exit 1
+```
+
+**Benefits:**
+- Container-level health monitoring
+- Works outside Kubernetes
+- Complements Kubernetes probes
+
+[Learn more about HEALTHCHECK](https://docs.docker.com/engine/reference/builder/#healthcheck).
+
+---
+
+### CKV_DOCKER_3: Non-Root Docker User
+
+**Check:** Ensure that a user for the container has been created
+
+**Current Implementation:** Containers run as default root user.
+
+**Reasoning:** Ensures compatibility with demo images and avoids permission issues.
+
+**Production Recommendation:** Create non-root user in Dockerfile:
+
+```dockerfile
+FROM python:3.12-slim
+
+# Create non-root user
+RUN groupadd -r appuser && useradd -r -g appuser -u 1000 appuser
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+# Switch to non-root user
+USER appuser
+
+COPY app.py .
+CMD ["python", "app.py"]
+```
+
+[Learn more about non-root Docker users](https://docs.docker.com/engine/reference/builder/#user).
+
+---
+
+## Production Security Checklist
+
+Before deploying to production, implement these security enhancements:
+
+### Infrastructure
+
+- [ ] Enable encryption at rest for EBS volumes with customer-managed KMS keys
+- [ ] Enable encryption in transit for all services
+- [ ] Use private subnets for worker nodes
+- [ ] Implement VPC Flow Logs
+- [ ] Enable CloudTrail for API auditing
+- [ ] Use AWS Secrets Manager or HashiCorp Vault for secrets
+- [ ] Enable ECR image scanning
+- [ ] Enable ECR image tag immutability
+- [ ] Implement backup and disaster recovery
+
+### Kubernetes
+
+- [ ] Implement NetworkPolicies for all namespaces
+- [ ] Enable Pod Security Standards (Restricted)
+- [ ] Configure liveness and readiness probes
+- [ ] Set resource requests and limits
+- [ ] Use read-only root filesystems where possible
+- [ ] Run containers as non-root with high UIDs
+- [ ] Mount secrets as files, not environment variables
+- [ ] Minimize container capabilities
+- [ ] Enable Kubernetes audit logging
+- [ ] Implement RBAC with principle of least privilege
+
+### Application
+
+- [ ] Build custom images with security hardening
+- [ ] Add HEALTHCHECK instructions to Dockerfiles
+- [ ] Scan images for vulnerabilities (Trivy, Grype)
+- [ ] Use multi-stage builds to reduce image size
+- [ ] Pin dependency versions
+- [ ] Remove unnecessary packages and files
+- [ ] Sign container images
+- [ ] Implement authentication and authorization
+- [ ] Enable TLS for all internal communication
+- [ ] Implement rate limiting and DDoS protection
+
+### Monitoring & Compliance
+
+- [ ] Set up security monitoring and alerting
+- [ ] Implement log aggregation and analysis
+- [ ] Enable AWS GuardDuty
+- [ ] Enable AWS Security Hub
+- [ ] Conduct regular security audits
+- [ ] Perform penetration testing
+- [ ] Document security procedures
+- [ ] Create incident response plan
+- [ ] Train team on security best practices
+
+---
+
+## Additional Security Resources
+
+- [EKS Best Practices for Security](https://aws.github.io/aws-eks-best-practices/security/docs/)
+- [Kubernetes Security Best Practices](https://kubernetes.io/docs/concepts/security/security-checklist/)
+- [OWASP Kubernetes Top 10](https://owasp.org/www-project-kubernetes-top-ten/)
+- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes)
+- [NIST Application Container Security Guide](https://csrc.nist.gov/publications/detail/sp/800-190/final)
+
+---
+
+## Responsible Disclosure
+
+If you discover a security vulnerability in this project, please report it responsibly:
+
+1. **Do not** create a public GitHub issue
+2. Email the maintainers with details
+3. Allow time for investigation and patching
+4. Follow coordinated disclosure practices
+
+See the repository root `SECURITY.md` for complete reporting guidelines.
+
+---
+
+## Disclaimer
+
+!!! danger "Production Deployment"
+    This project prioritizes ease of use for demonstration and learning. Before deploying to production:
+    
+    - Implement all security recommendations in this document
+    - Conduct thorough security assessment
+    - Perform penetration testing
+    - Establish monitoring and incident response
+    - Consult security professionals
+    - Review and comply with organizational security policies
+    
+    **Use at your own risk.** The authors are not responsible for security incidents resulting from production deployment of this demonstration code.
+
+---
+
+## See Also
+
+- [Configuration Guide](configuration.md)
+- [CLI Commands Reference](cli-commands.md)
+- [FAQ](faq.md)

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5
+mkdocs-minify-plugin>=0.8

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,133 @@
+site_name: GenAI on EKS Starter Kit
+site_url: https://aws-samples.github.io/sample-genai-on-eks-starter-kit/
+site_description: A starter kit for deploying and managing GenAI components on Amazon EKS
+repo_url: https://github.com/aws-samples/sample-genai-on-eks-starter-kit
+repo_name: aws-samples/sample-genai-on-eks-starter-kit
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  logo: assets/images/logo.svg
+  favicon: assets/images/logo.svg
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: amber
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - navigation.footer
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.code.annotate
+    - content.action.edit
+    - toc.follow
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+  - minify:
+      minify_html: true
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - attr_list
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/aws-samples/sample-genai-on-eks-starter-kit
+
+nav:
+  - Home: index.md
+  - Getting Started:
+    - Prerequisites: getting-started/prerequisites.md
+    - Quick Start: getting-started/quick-start.md
+    - Infrastructure Setup: getting-started/infrastructure.md
+    - Demo Walkthrough: getting-started/demo-walkthrough.md
+  - Components:
+    - Overview: components/index.md
+    - NVIDIA Platform:
+      - Overview: components/nvidia-platform/index.md
+      - GPU Operator: components/nvidia-platform/gpu-operator.md
+      - Monitoring: components/nvidia-platform/monitoring.md
+      - Dynamo Platform: components/nvidia-platform/dynamo-platform.md
+      - Dynamo vLLM Serving: components/nvidia-platform/dynamo-vllm.md
+      - AIPerf Benchmark: components/nvidia-platform/benchmark.md
+      - AIConfigurator: components/nvidia-platform/aiconfigurator.md
+    - AI Gateway:
+      - LiteLLM: components/ai-gateway/litellm.md
+      - Kong: components/ai-gateway/kong.md
+    - LLM Model:
+      - vLLM: components/llm-model/vllm.md
+      - SGLang: components/llm-model/sglang.md
+      - TGI: components/llm-model/tgi.md
+      - Ollama: components/llm-model/ollama.md
+    - Embedding Model:
+      - Text Embedding Inference (TEI): components/embedding-model/tei.md
+    - Guardrail:
+      - Guardrails AI: components/guardrail/guardrails-ai.md
+    - Observability:
+      - Langfuse: components/observability/langfuse.md
+      - MLflow: components/observability/mlflow.md
+      - Phoenix: components/observability/phoenix.md
+    - GUI App:
+      - Open WebUI: components/gui-app/openwebui.md
+    - Vector Database:
+      - Qdrant: components/vector-database/qdrant.md
+      - Chroma: components/vector-database/chroma.md
+      - Milvus: components/vector-database/milvus.md
+    - Workflow Automation:
+      - n8n: components/workflow-automation/n8n.md
+    - AI Agent:
+      - OpenClaw: components/ai-agent/openclaw.md
+  - Examples:
+    - Overview: examples/index.md
+    - MCP Server:
+      - Calculator: examples/mcp-server/calculator.md
+    - Strands Agents:
+      - Calculator Agent: examples/strands-agents/calculator-agent.md
+    - Agno:
+      - Calculator Agent: examples/agno/calculator-agent.md
+    - OpenClaw:
+      - Document Writer: examples/openclaw/doc-writer.md
+      - DevOps Agent: examples/openclaw/devops-agent.md
+  - Reference:
+    - CLI Commands: reference/cli-commands.md
+    - Configuration: reference/configuration.md
+    - FAQ: reference/faq.md
+    - Security: reference/security.md


### PR DESCRIPTION
## Summary
- Set up MkDocs Material documentation site with GitHub Actions auto-deployment to GitHub Pages
- Add 13 missing component documentation pages (TGI, Ollama, TEI, Guardrails AI, Langfuse, MLflow, Phoenix, Open WebUI, Qdrant, Chroma, Milvus, n8n, OpenClaw)
- Fix 16 broken links across 6 existing doc files

## Changes
- `mkdocs.yml` — Material theme with dark/light mode, search, mermaid diagrams, code copy
- `.github/workflows/docs.yml` — GitHub Actions workflow (build on push to main, deploy to Pages)
- `docs/requirements.txt` — Python dependencies (mkdocs-material, mkdocs-minify-plugin)
- `docs/components/**` — 13 new component doc pages following existing pattern
- `docs/**` — Fixed broken relative links and removed references to non-existent images

## Test plan
- [x] `mkdocs build --strict` passes with 0 warnings
- [x] Local `mkdocs serve` verified in browser
- [ ] After merge, verify GitHub Actions workflow runs and deploys to GitHub Pages
- [ ] Verify site is accessible at https://aws-samples.github.io/sample-genai-on-eks-starter-kit/