### PR TITLE
feat: Add External Secrets Operator component

### DIFF
--- a/cli-menu.json
+++ b/cli-menu.json
@@ -42,7 +42,8 @@
       "components": [
         { "dir": "langfuse", "name": "Langfuse" },
         { "dir": "mlflow", "name": "MLflow" },
-        { "dir": "phoenix", "name": "Phoenix" }
+        { "dir": "phoenix", "name": "Phoenix" },
+        { "dir": "amp-amg", "name": "Amazon Managed Prometheus & Grafana (AMP/AMG)" }
       ]
     },
     { "dir": "gui-app", "name": "GUI App", "components": [{ "dir": "openwebui", "name": "Open WebUI" }] },
@@ -56,7 +57,8 @@
       ]
     },
     { "dir": "workflow-automation", "name": "Workflow Automation", "components": [{ "dir": "n8n", "name": "n8n" }] },
-    { "dir": "ai-agent", "name": "AI Agent", "components": [{ "dir": "openclaw", "name": "OpenClaw" }] }
+    { "dir": "ai-agent", "name": "AI Agent", "components": [{ "dir": "openclaw", "name": "OpenClaw" }] },
+    { "dir": "security", "name": "Security", "components": [{ "dir": "external-secrets", "name": "External Secrets Operator" }] }
   ],
   "exampleCategories": [
     { "dir": "mcp-server", "name": "MCP Server", "examples": [{ "dir": "calculator", "name": "Calculator" }] },

--- a/components/security/external-secrets/.terraform.lock.hcl
+++ b/components/security/external-secrets/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.96.0"
+  constraints = "~> 5.96.0"
+  hashes = [
+    "h1:a/VEUu6BGQSPlUAzbN+zqaDCdi0QGh/VzBgo2gCran0=",
+    "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
+    "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
+    "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",
+    "zh:68f2328e7f3e7666835d6815b39b46b08954a91204f82a6f648c928a0b09a744",
+    "zh:6a4170e7e2764df2968d1df65efebda55273dfc36dc6741207afb5e4b7e85448",
+    "zh:73f2a15bee21f7c92a071e2520216d0a40041aca52c0f6682e540da8ffcfada4",
+    "zh:9843d6973aedfd4cbaafd7110420d0c4c1d7ef4a2eeff508294c3adcc3613145",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d1abd6be717c42f2a6257ee227d3e9548c31f01c976ed7b32b2745a63659a67",
+    "zh:a70d642e323021d54a92f0daa81d096cb5067cb99ce116047a42eb1cb1d579a0",
+    "zh:b9a2b293208d5a0449275fae463319e0998c841e0bcd4014594a49ba54bb70d6",
+    "zh:ce0b0eb7ac24ff58c20efcb526c3f792a95be3617c795b45bbeea9f302903ae7",
+    "zh:dbbf98b3cd8003833c472bdb89321c17a9bbdc1b785e7e3d75f8af924ee5a0e4",
+    "zh:df86cf9311a4be8bb4a251196650653f97e01fbf5fe72deecc8f28a35a5352ae",
+    "zh:f92992881afd9339f3e539fcd90cfc1e9ed1356b5e760bbcc804314c3cd6837f",
+  ]
+}

--- a/components/security/external-secrets/cluster-secret-store.template.yaml
+++ b/components/security/external-secrets/cluster-secret-store.template.yaml
@@ -1,0 +1,19 @@
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: aws-secrets-manager
+spec:
+  provider:
+    aws:
+      service: SecretsManager
+      region: {{AWS_REGION}}
+---
+apiVersion: external-secrets.io/v1
+kind: ClusterSecretStore
+metadata:
+  name: aws-parameter-store
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: {{AWS_REGION}}

--- a/components/security/external-secrets/index.mjs
+++ b/components/security/external-secrets/index.mjs
@@ -1,0 +1,141 @@
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+import handlebars from "handlebars";
+import { $ } from "zx";
+$.verbose = true;
+
+export const name = "External Secrets Operator";
+const __filename = fileURLToPath(import.meta.url);
+const DIR = path.dirname(__filename);
+let BASE_DIR;
+let config;
+let utils;
+
+const NAMESPACE = "external-secrets";
+
+export async function init(_BASE_DIR, _config, _utils) {
+  BASE_DIR = _BASE_DIR;
+  config = _config;
+  utils = _utils;
+}
+
+export async function install() {
+  const requiredEnvVars = ["REGION", "EKS_CLUSTER_NAME"];
+  utils.checkRequiredEnvVars(requiredEnvVars);
+
+  console.log("\n========================================");
+  console.log("Installing External Secrets Operator");
+  console.log("(ESO + AWS Secrets Manager / Parameter Store)");
+  console.log("========================================\n");
+
+  // Step 1: Provision IAM role and Pod Identity via Terraform
+  console.log("[1/4] Provisioning IAM role for ESO (Terraform)...");
+  await utils.terraform.apply(DIR);
+  const tfOutput = await utils.terraform.output(DIR, {});
+  const esoRoleArn = tfOutput.eso_role_arn.value;
+  console.log(`  IAM Role: ${esoRoleArn}`);
+
+  // Step 2: Add Helm repo and install ESO
+  console.log("\n[2/4] Installing External Secrets Operator (Helm)...");
+  await $`helm repo add external-secrets https://charts.external-secrets.io --force-update`;
+  await $`helm repo update`;
+
+  const valuesTemplatePath = path.join(DIR, "values.template.yaml");
+  const valuesRenderedPath = path.join(DIR, "values.rendered.yaml");
+  const valuesTemplateString = fs.readFileSync(valuesTemplatePath, "utf8");
+  const valuesTemplate = handlebars.compile(valuesTemplateString);
+  fs.writeFileSync(valuesRenderedPath, valuesTemplate({}));
+
+  await $`helm upgrade --install external-secrets \
+    external-secrets/external-secrets \
+    --namespace ${NAMESPACE} \
+    --create-namespace \
+    -f ${valuesRenderedPath} \
+    --wait --timeout 5m`;
+
+  console.log("  ✅ External Secrets Operator installed");
+
+  // Step 3: Wait for CRDs and webhook to be ready
+  console.log("\n[3/4] Waiting for ESO webhook to be ready...");
+  await $`kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=external-secrets-webhook -n ${NAMESPACE} --timeout=120s`;
+
+  // Step 4: Create ClusterSecretStores for AWS backends
+  console.log("\n[4/4] Creating ClusterSecretStores...");
+  const cssTemplatePath = path.join(DIR, "cluster-secret-store.template.yaml");
+  const cssRenderedPath = path.join(DIR, "cluster-secret-store.rendered.yaml");
+  const cssTemplateString = fs.readFileSync(cssTemplatePath, "utf8");
+  const cssTemplate = handlebars.compile(cssTemplateString);
+  fs.writeFileSync(cssRenderedPath, cssTemplate({ AWS_REGION: process.env.REGION }));
+
+  await $`kubectl apply -f ${cssRenderedPath}`;
+  console.log("  ✅ ClusterSecretStore 'aws-secrets-manager' created");
+  console.log("  ✅ ClusterSecretStore 'aws-parameter-store' created");
+
+  // Print status
+  await printStatus();
+
+  console.log("\n========================================");
+  console.log("Next Steps");
+  console.log("========================================");
+  console.log("Create ExternalSecret resources to sync secrets from AWS:");
+  console.log("  apiVersion: external-secrets.io/v1beta1");
+  console.log("  kind: ExternalSecret");
+  console.log("  spec:");
+  console.log("    secretStoreRef:");
+  console.log("      name: aws-secrets-manager");
+  console.log("      kind: ClusterSecretStore");
+  console.log("    target:");
+  console.log("      name: my-k8s-secret");
+  console.log("    data:");
+  console.log("      - secretKey: api-key");
+  console.log("        remoteRef:");
+  console.log("          key: my-aws-secret-name");
+}
+
+async function printStatus() {
+  console.log("\n--- ESO Pods ---");
+  try {
+    await $`kubectl get pods -n ${NAMESPACE}`;
+  } catch {
+    console.log("  (No pods found)");
+  }
+
+  console.log("\n--- ClusterSecretStores ---");
+  try {
+    await $`kubectl get clustersecretstores`;
+  } catch {
+    console.log("  (No ClusterSecretStores found)");
+  }
+}
+
+export async function uninstall() {
+  console.log("\nUninstalling External Secrets Operator...");
+
+  // Remove ClusterSecretStores
+  try {
+    await $`kubectl delete clustersecretstore aws-secrets-manager aws-parameter-store --ignore-not-found`;
+    console.log("ClusterSecretStores removed.");
+  } catch {
+    // ignore
+  }
+
+  // Uninstall Helm release
+  try {
+    await $`helm uninstall external-secrets --namespace ${NAMESPACE}`;
+    console.log("ESO Helm release uninstalled.");
+  } catch {
+    console.log("ESO not found or already removed.");
+  }
+
+  // Delete namespace
+  try {
+    await $`kubectl delete namespace ${NAMESPACE} --ignore-not-found`;
+  } catch {
+    // ignore
+  }
+
+  // Destroy Terraform resources (IAM role, Pod Identity)
+  await utils.terraform.destroy(DIR);
+  console.log("ESO infrastructure destroyed.");
+}

--- a/components/security/external-secrets/main.tf
+++ b/components/security/external-secrets/main.tf
@@ -1,0 +1,73 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+variable "name" {
+  type    = string
+  default = "genai-on-eks"
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.96.0"
+    }
+  }
+}
+provider "aws" {
+  region = var.region
+}
+
+# ─── IAM Role for External Secrets Operator ──────────────────────
+resource "aws_iam_role" "external_secrets" {
+  name = "${var.name}-${var.region}-external-secrets"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "pods.eks.amazonaws.com"
+      }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "external_secrets_sm" {
+  role = aws_iam_role.external_secrets.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue",
+          "secretsmanager:DescribeSecret",
+          "secretsmanager:ListSecrets"
+        ]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "ssm:GetParameter",
+          "ssm:GetParameters",
+          "ssm:GetParametersByPath"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_eks_pod_identity_association" "external_secrets" {
+  cluster_name    = var.name
+  namespace       = "external-secrets"
+  service_account = "external-secrets"
+  role_arn        = aws_iam_role.external_secrets.arn
+}
+
+# ─── Outputs ─────────────────────────────────────────────────────
+output "eso_role_arn" {
+  value = aws_iam_role.external_secrets.arn
+}

--- a/components/security/external-secrets/values.template.yaml
+++ b/components/security/external-secrets/values.template.yaml
@@ -1,0 +1,35 @@
+installCRDs: true
+
+serviceAccount:
+  create: true
+  name: external-secrets
+
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: 200m
+    memory: 256Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+webhook:
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+certController:
+  replicaCount: 1
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi

--- a/config.json
+++ b/config.json
@@ -6,7 +6,8 @@
       { "category": "gui-app", "component": "openwebui" },
       { "category": "vector-database", "component": "qdrant" },
       { "category": "embedding-model", "component": "tei" },
-      { "category": "ai-gateway", "component": "litellm" }
+      { "category": "ai-gateway", "component": "litellm" },
+      { "category": "security", "component": "external-secrets" }
     ],
     "examples": [
       { "category": "mcp-server", "example": "calculator" },


### PR DESCRIPTION
## Summary

- Add new `security/external-secrets` component that installs External Secrets Operator via Helm
- Terraform provisions IAM role with Secrets Manager & Parameter Store read access, linked via Pod Identity
- Creates ClusterSecretStores for both AWS Secrets Manager and Parameter Store backends
- Register new `security` category in `cli-menu.json` and add to `config.json` demo list

## Components

| Resource | Purpose |
|----------|---------|
| External Secrets Operator | K8s operator syncing external secrets |
| ClusterSecretStore (SM) | Cluster-wide store for AWS Secrets Manager |
| ClusterSecretStore (SSM) | Cluster-wide store for AWS Parameter Store |
| IAM Role | Pod Identity role with SM/SSM read access |

## Files

- `components/security/external-secrets/index.mjs` — Install/uninstall logic
- `components/security/external-secrets/main.tf` — Terraform for IAM, Pod Identity
- `components/security/external-secrets/values.template.yaml` — ESO Helm values
- `components/security/external-secrets/cluster-secret-store.template.yaml` — ClusterSecretStore manifests
- `cli-menu.json` — Register new Security category
- `config.json` — Add to demo components

## Test plan

- [ ] Run `./cli security external-secrets install` and verify ESO pods are running
- [ ] Verify ClusterSecretStores: `kubectl get clustersecretstores`
- [ ] Create a test secret in AWS Secrets Manager and verify ExternalSecret syncs it
- [ ] Run `./cli security external-secrets uninstall` and confirm cleanup

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)