### PR TITLE
fix: Add REGION fallback for Langfuse and MLflow S3 configuration

### DIFF
--- a/components/o11y/langfuse/index.mjs
+++ b/components/o11y/langfuse/index.mjs
@@ -42,7 +42,7 @@ export async function install() {
     LANGFUSE_PUBLIC_KEY: process.env.LANGFUSE_PUBLIC_KEY,
     LANGFUSE_SECRET_KEY: process.env.LANGFUSE_SECRET_KEY,
     LANGFUSE_BUCKET_NAME: langfuseBucketName,
-    AWS_REGION: process.env.AWS_REGION,
+    AWS_REGION: process.env.REGION || process.env.AWS_REGION,
   };
   fs.writeFileSync(valuesRenderedPath, valuesTemplate(valuesVars));
   await $`helm upgrade --install langfuse langfuse/langfuse --namespace langfuse --create-namespace -f ${valuesRenderedPath}`;

--- a/components/o11y/mlflow/index.mjs
+++ b/components/o11y/mlflow/index.mjs
@@ -34,7 +34,7 @@ export async function install() {
     MLFLOW_USERNAME: process.env.MLFLOW_USERNAME,
     MLFLOW_PASSWORD: process.env.MLFLOW_PASSWORD,
     MLFLOW_BUCKET_NAME: mlflowBucketName,
-    AWS_REGION: process.env.AWS_REGION,
+    AWS_REGION: process.env.REGION || process.env.AWS_REGION,
   };
   fs.writeFileSync(valuesRenderedPath, valuesTemplate(valuesVars));
   await $`helm repo add community-charts https://community-charts.github.io/helm-charts`;


### PR DESCRIPTION
## Summary

- Fix S3 PermanentRedirect errors in Langfuse and MLflow when `.env` defines `REGION` but not `AWS_REGION`
- `process.env.AWS_REGION` is undefined → S3 defaults to us-east-1 endpoint → bucket redirect error

## Changes

- `components/o11y/langfuse/index.mjs`: `process.env.AWS_REGION` → `process.env.REGION || process.env.AWS_REGION`
- `components/o11y/mlflow/index.mjs`: same fix

## Root Cause

The `.env` file defines `REGION=us-west-2` but templates reference `AWS_REGION`. When `AWS_REGION` is not set, the Handlebars template renders an empty string, causing S3 to default to `us-east-1`.

## Test plan

- [ ] Deploy Langfuse with `REGION=ap-northeast-2` in `.env` (without `AWS_REGION`)
- [ ] Verify `LANGFUSE_S3_EVENT_UPLOAD_REGION` is `ap-northeast-2` (not `us-east-1`)
- [ ] Confirm Langfuse traces are stored in S3 without PermanentRedirect errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)