### PR TITLE
Add LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST for LiteLLM connection

### DIFF
--- a/components/o11y/langfuse/values.template.yaml
+++ b/components/o11y/langfuse/values.template.yaml
@@ -39,6 +39,8 @@ langfuse:
       value: {{{LANGFUSE_USERNAME}}}
     - name: LANGFUSE_INIT_USER_PASSWORD
       value: {{{LANGFUSE_PASSWORD}}}
+    - name: LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST
+      value: litellm.litellm.svc.cluster.local
   resources:
     requests:
       cpu: 1 


### PR DESCRIPTION
*Issue #, if available:* #133

*Description of changes:*

- Langfuse's SSRF protection blocks LLM connection to LiteLLM because `litellm.litellm.svc.cluster.local` resolves to a private IP address
- Add `LANGFUSE_LLM_CONNECTION_WHITELISTED_HOST` env var to whitelist the internal LiteLLM service hostname
- Fixes LLM-as-a-Judge evaluator setup (Workshop: LLM Evaluation with Langfuse - Step 2: Set Up Default Evaluator Model)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.