### PR TITLE
Attach session_id and tags to Langfuse traces in Loan Buddy agent

### DIFF
--- a/workshops/eks-genai-workshop/static/code/module3/credit-validation/agentic-application-deployment.yaml
+++ b/workshops/eks-genai-workshop/static/code/module3/credit-validation/agentic-application-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: langfuse
       containers:
       - name: loan-buddy-agent
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.2
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
         imagePullPolicy: Always
         command: ["python", "/app/credit-underwriting-agent.py"]
         env:
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: mcp-address-validator
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.2
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
         imagePullPolicy: Always
         command: ["python", "/app/mcp-address-validator.py"]
         resources:
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
       - name: mcp-employment-validator
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.2
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
         command: ["python", "/app/mcp-income-employment-validator.py"]
         imagePullPolicy: Always        
         resources:
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: langfuse
       containers:
       - name: mcp-image-processor
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.2
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
         command: ["python", "/app/mcp-image-processor.py"]
         imagePullPolicy: Always        
         env:

--- a/workshops/eks-genai-workshop/static/code/module3/credit-validation/agentic-application-deployment.yaml
+++ b/workshops/eks-genai-workshop/static/code/module3/credit-validation/agentic-application-deployment.yaml
@@ -17,7 +17,7 @@ spec:
       serviceAccountName: langfuse
       containers:
       - name: loan-buddy-agent
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.4
         imagePullPolicy: Always
         command: ["python", "/app/credit-underwriting-agent.py"]
         env:
@@ -70,7 +70,7 @@ spec:
     spec:
       containers:
       - name: mcp-address-validator
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.4
         imagePullPolicy: Always
         command: ["python", "/app/mcp-address-validator.py"]
         resources:
@@ -98,7 +98,7 @@ spec:
     spec:
       containers:
       - name: mcp-employment-validator
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.4
         command: ["python", "/app/mcp-income-employment-validator.py"]
         imagePullPolicy: Always        
         resources:
@@ -127,7 +127,7 @@ spec:
       serviceAccountName: langfuse
       containers:
       - name: mcp-image-processor
-        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.3
+        image: public.ecr.aws/agentic-ai-platforms-on-k8s/loan-buddy-example:1.0.4
         command: ["python", "/app/mcp-image-processor.py"]
         imagePullPolicy: Always        
         env:

--- a/workshops/eks-genai-workshop/static/code/module3/credit-validation/credit-underwriting-agent.py
+++ b/workshops/eks-genai-workshop/static/code/module3/credit-validation/credit-underwriting-agent.py
@@ -192,6 +192,11 @@ async def process_credit_application_with_upload(image_file: UploadFile = File(.
         graph = graph.with_config({
             "run_name": "credit_underwriting_agent_with_image_id",
             "callbacks": callbacks,
+            "tags": ["loan-processing", "agent", "langgraph"],
+            "metadata": {
+                "langfuse_session_id": "loan-buddy",
+                "langfuse_tags": ["loan-processing", "agent", "langgraph"],
+            },
             "recursion_limit": 20,
         })
         


### PR DESCRIPTION
## Problem

When running the Loan Buddy agent that ships in `workshops/eks-genai-workshop/static/code/module3/credit-validation/`, Langfuse traces show the correct `run_name` (`credit_underwriting_agent_with_image_id`), but **Session ID and Tags are always empty** in the Langfuse UI.

This breaks Module 4's evaluator setup — Langfuse Custom Evaluators require a Target/Filter such as `Tags contains loan-processing` or a Session-ID filter to auto-score traces, and neither selector matches because the fields aren't populated.

## Root cause

Langfuse Python SDK v3 (currently pinned by `requirements.txt` → installs 3.14.4) no longer forwards LangChain's `RunnableConfig["tags"]` to the Langfuse trace. The SDK instead reads tags and session id from `config["metadata"]` under recognized keys (`langfuse_tags`, `langfuse_session_id`). See [Langfuse LangChain integration — Adding tags and a session id](https://langfuse.com/docs/integrations/langchain/tracing).

The current code only sets `callbacks` and `run_name` — nothing flows to the trace metadata — so the UI has no way to display Tags or Session.

## Fix

Attach the three values via `config["metadata"]` (and keep `config["tags"]` for LangChain-side observability) on the existing `graph.with_config({...})` call in `credit-underwriting-agent.py`:

```py
"tags": ["loan-processing", "agent", "langgraph"],
"metadata": {
    "langfuse_session_id": "loan-buddy",
    "langfuse_tags": ["loan-processing", "agent", "langgraph"],
},
```

One file changed, five lines added, no behavior change beyond trace metadata.

## How to verify

1. Rebuild/redeploy the Loan Buddy agent image.
2. Trigger a loan application in the usual way.
3. Open the trace in Langfuse — the **Session** column shows `loan-buddy` and the **Tags** column shows `loan-processing / agent / langgraph`.
4. In Module 4's LLM-as-a-Judge, an evaluator with filter `Tags contains loan-processing` now matches and auto-scores the trace.

## Testing

Verified against Langfuse `3.169.0` (langfuse-web) with Langfuse Python SDK `3.14.4` on a provisioned workshop environment.