### PR TITLE
docs(flexible-ai): add Flexible AI section with bilingual landing pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,10 @@ name: Deploy Documentation
 
 on:
   push:
-    branches:
-      - main
-      - feat/flex-ai-landing
+    branches: [main]
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
-      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,13 @@ name: Deploy Documentation
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - feat/flex-ai-landing
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - '.github/workflows/docs.yml'
   workflow_dispatch:
 
 permissions:

--- a/docs/flex-ai/architecture.ko.md
+++ b/docs/flex-ai/architecture.ko.md
@@ -1,0 +1,139 @@
+---
+title: Architecture
+---
+
+[한국어](architecture.ko.md){ .md-button .md-button--primary } [English](architecture.md){ .md-button }
+
+# Functional View & Building Blocks
+
+Application 레이어부터 Cloud·On-prem·Edge 인프라까지 전 계층을 포괄하는 구조입니다. 환경에 맞춰 필요한 컴포넌트부터 점진적으로 확장하거나, 통합 플랫폼으로 한 번에 구축할 수 있습니다.
+
+## 계층 구조
+
+```mermaid
+flowchart TB
+    subgraph U["Users & Clients"]
+        UI["Open WebUI / Self-service portal"]
+        APP["Custom apps & agents"]
+        WF["Workflow automation (n8n)"]
+    end
+
+    subgraph G["Gateway & Guardrails"]
+        GW["AI Gateway<br/>(LiteLLM / Kong)"]
+        GR["Guardrails AI"]
+    end
+
+    subgraph A["Agentic Layer"]
+        AG["Agents<br/>(LangGraph / Strands / Agno / OpenClaw)"]
+        MCP["MCP Servers (A2A)"]
+        VDB["Vector DB / S3 Vectors<br/>(Qdrant / Chroma / Milvus)"]
+        MEM["Memory (Mem0)"]
+    end
+
+    subgraph M["Model Serving"]
+        LLM["Self-hosted LLM<br/>(vLLM / SGLang / Ollama / Ray)"]
+        EMB["Embedding (TEI)"]
+        DYN["NVIDIA Dynamo Platform"]
+        BR["Amazon Bedrock / Nova / SageMaker"]
+        EXT["External LLM<br/>(OpenAI / Gemini / Anthropic)"]
+    end
+
+    subgraph O["Observability"]
+        LF["Langfuse"]
+        PHX["Phoenix"]
+        ML["MLflow"]
+    end
+
+    subgraph I["Compute & Infrastructure"]
+        EKS["Amazon EKS / EKS Hybrid Node"]
+        GPU["GPU"]
+        TRN["Trainium / Inferentia"]
+        GRV["Graviton"]
+        ALB["ALB + ACM"]
+        S3V["S3 Vectors / EFS"]
+        IAM["IRSA + Secrets Manager"]
+    end
+
+    UI --> GW
+    APP --> GW
+    WF --> GW
+    GW --> GR
+    GR --> LLM
+    GR --> BR
+    GR --> EXT
+    GW --> AG
+    AG --> MCP
+    AG --> VDB
+    AG --> MEM
+    AG --> LLM
+    LLM --> DYN
+    GW --> LF
+    AG --> LF
+    LLM --> PHX
+    AG --> ML
+
+    EKS --- GPU
+    EKS --- TRN
+    EKS --- GRV
+    EKS --- ALB
+    EKS --- S3V
+    EKS --- IAM
+```
+
+## 빌딩 블록
+
+### Application Layer
+
+- **Self-service portal** — 모델·에이전트에 대한 통합 액세스를 단일 UI에서 제공.
+- **Open WebUI / Custom Applications / n8n** — 사용자와 워크플로우 자동화가 게이트웨이를 통해 동일한 진입점을 사용.
+
+### Gateway & Guardrails
+
+- [LiteLLM](../components/ai-gateway/litellm.md) — OpenAI 호환 프록시, multi-provider routing.
+- [Kong AI Gateway OSS](../components/ai-gateway/kong.md) — Kong 기반 AI 플러그인.
+- [Guardrails AI](../components/guardrail/guardrails-ai.md) — 정책 강제 및 안전 가드.
+
+### Agentic Layer
+
+- **LangGraph / Strands / Agno / OpenClaw** — 에이전트 워크플로우 프레임워크. 코드 레벨에서 완전 제어.
+- **MCP Servers** — Model Context Protocol을 통해 도구를 서비스로 노출 ([Calculator MCP](../examples/mcp-server/calculator.md)).
+- **Vector DB / S3 Vectors / Memory(Mem0)** — RAG와 장기 메모리.
+
+### Model Serving
+
+- 자체 호스팅: [vLLM](../components/llm-model/vllm.md), [SGLang](../components/llm-model/sglang.md), [TGI](../components/llm-model/tgi.md), [Ollama](../components/llm-model/ollama.md), [TEI](../components/embedding-model/tei.md).
+- AWS 관리형: Amazon Bedrock, Nova, SageMaker.
+- 외부 LLM: OpenAI, Gemini, Anthropic — 동일 게이트웨이로 라우팅.
+- 고도화 경로: [NVIDIA Dynamo Platform](../components/nvidia-platform/index.md) (KV-cache routing, AIPerf, AIConfigurator).
+
+### Observability
+
+- [Langfuse](../components/observability/langfuse.md) — LLM·에이전트 트레이싱, 세션·태그 단위 분석.
+- [Phoenix](../components/observability/phoenix.md) — 평가·모니터링.
+- [MLflow](../components/observability/mlflow.md) — 실험 추적.
+
+### Compute & Infrastructure
+
+- **Amazon EKS / EKS Hybrid Node** — AWS Cloud와 온프레미스를 하나의 클러스터로 통합.
+- **이기종 컴퓨트** — Workload별 GPU / Trainium / Inferentia / Graviton 조합.
+- **ALB + ACM, S3 Vectors / EFS, IRSA + Secrets Manager** — 프로덕션-grade 디폴트.
+
+## 구성 모델
+
+모든 컴포넌트는 다음 머지 순서로 구성을 읽습니다.
+
+```
+.env -> config.json -> .env.local -> config.local.json
+```
+
+CLI 서브커맨드는 머지된 결과를 입력으로 Handlebars 템플릿을 `*.rendered.yaml`로 렌더링한 뒤 적용합니다. 모든 카테고리에서 동일한 패턴을 사용하므로, 한 컴포넌트를 이해하면 나머지도 같은 방식으로 동작합니다.
+
+자세한 스키마는 [Configuration](../reference/configuration.md)을 참고하세요.
+
+## 배포 형태
+
+- **Demo setup** — `./cli demo-setup` 으로 큐레이션된 스택을 병렬 설치 (`openwebui`는 `litellm` 이후 등 명시적 의존성 적용). [Quick Start](../getting-started/quick-start.md)
+- **Interactive setup** — `./cli interactive-setup` 으로 카테고리별 컴포넌트 선택. 둘 다 동일한 클러스터 형태를 산출합니다.
+
+[:octicons-arrow-right-24: Use Cases](use-cases.ko.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Get Started](get-started.ko.md){ .md-button }

--- a/docs/flex-ai/architecture.md
+++ b/docs/flex-ai/architecture.md
@@ -6,7 +6,7 @@ title: Architecture
 
 # Functional View & Building Blocks
 
-Flex AI spans every layer from the application surface down to cloud, on-premises, and edge infrastructure. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.
+Flexible AI spans every layer from the application surface down to cloud, on-premises, and edge infrastructure. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.
 
 ## Layered stack
 

--- a/docs/flex-ai/architecture.md
+++ b/docs/flex-ai/architecture.md
@@ -1,0 +1,139 @@
+---
+title: Architecture
+---
+
+[한국어](architecture.ko.md){ .md-button } [English](architecture.md){ .md-button .md-button--primary }
+
+# Functional View & Building Blocks
+
+Flex AI spans every layer from the application surface down to cloud, on-premises, and edge infrastructure. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.
+
+## Layered stack
+
+```mermaid
+flowchart TB
+    subgraph U["Users & Clients"]
+        UI["Open WebUI / Self-service portal"]
+        APP["Custom apps & agents"]
+        WF["Workflow automation (n8n)"]
+    end
+
+    subgraph G["Gateway & Guardrails"]
+        GW["AI Gateway<br/>(LiteLLM / Kong)"]
+        GR["Guardrails AI"]
+    end
+
+    subgraph A["Agentic Layer"]
+        AG["Agents<br/>(LangGraph / Strands / Agno / OpenClaw)"]
+        MCP["MCP Servers (A2A)"]
+        VDB["Vector DB / S3 Vectors<br/>(Qdrant / Chroma / Milvus)"]
+        MEM["Memory (Mem0)"]
+    end
+
+    subgraph M["Model Serving"]
+        LLM["Self-hosted LLM<br/>(vLLM / SGLang / Ollama / Ray)"]
+        EMB["Embedding (TEI)"]
+        DYN["NVIDIA Dynamo Platform"]
+        BR["Amazon Bedrock / Nova / SageMaker"]
+        EXT["External LLM<br/>(OpenAI / Gemini / Anthropic)"]
+    end
+
+    subgraph O["Observability"]
+        LF["Langfuse"]
+        PHX["Phoenix"]
+        ML["MLflow"]
+    end
+
+    subgraph I["Compute & Infrastructure"]
+        EKS["Amazon EKS / EKS Hybrid Node"]
+        GPU["GPU"]
+        TRN["Trainium / Inferentia"]
+        GRV["Graviton"]
+        ALB["ALB + ACM"]
+        S3V["S3 Vectors / EFS"]
+        IAM["IRSA + Secrets Manager"]
+    end
+
+    UI --> GW
+    APP --> GW
+    WF --> GW
+    GW --> GR
+    GR --> LLM
+    GR --> BR
+    GR --> EXT
+    GW --> AG
+    AG --> MCP
+    AG --> VDB
+    AG --> MEM
+    AG --> LLM
+    LLM --> DYN
+    GW --> LF
+    AG --> LF
+    LLM --> PHX
+    AG --> ML
+
+    EKS --- GPU
+    EKS --- TRN
+    EKS --- GRV
+    EKS --- ALB
+    EKS --- S3V
+    EKS --- IAM
+```
+
+## Building blocks
+
+### Application layer
+
+- **Self-service portal** — single UI for unified access to models and agents.
+- **Open WebUI / custom apps / n8n** — users and workflows enter through the same gateway.
+
+### Gateway & Guardrails
+
+- [LiteLLM](../components/ai-gateway/litellm.md) — OpenAI-compatible proxy with multi-provider routing.
+- [Kong AI Gateway OSS](../components/ai-gateway/kong.md) — Kong with AI plugins.
+- [Guardrails AI](../components/guardrail/guardrails-ai.md) — policy enforcement and safety guards.
+
+### Agentic layer
+
+- **LangGraph / Strands / Agno / OpenClaw** — agent workflow frameworks, fully controllable at the code level.
+- **MCP servers** — expose tools as services over Model Context Protocol ([Calculator MCP](../examples/mcp-server/calculator.md)).
+- **Vector DB / S3 Vectors / Memory (Mem0)** — RAG and long-term memory.
+
+### Model serving
+
+- Self-hosted: [vLLM](../components/llm-model/vllm.md), [SGLang](../components/llm-model/sglang.md), [TGI](../components/llm-model/tgi.md), [Ollama](../components/llm-model/ollama.md), [TEI](../components/embedding-model/tei.md).
+- AWS-managed: Amazon Bedrock, Nova, SageMaker.
+- External LLMs: OpenAI, Gemini, Anthropic — same gateway entry point.
+- Acceleration path: [NVIDIA Dynamo Platform](../components/nvidia-platform/index.md) (KV-cache routing, AIPerf, AIConfigurator).
+
+### Observability
+
+- [Langfuse](../components/observability/langfuse.md) — LLM and agent tracing with session / tag attribution.
+- [Phoenix](../components/observability/phoenix.md) — evaluation and monitoring.
+- [MLflow](../components/observability/mlflow.md) — experiment tracking.
+
+### Compute & infrastructure
+
+- **Amazon EKS / EKS Hybrid Node** — unify AWS Cloud and on-premises in one cluster.
+- **Heterogeneous compute** — mix GPU / Trainium / Inferentia / Graviton per workload.
+- **ALB + ACM, S3 Vectors / EFS, IRSA + Secrets Manager** — production-grade defaults.
+
+## Configuration model
+
+Every component reads configuration from this merge order:
+
+```
+.env -> config.json -> .env.local -> config.local.json
+```
+
+CLI subcommands consume the merged result, render Handlebars manifests into `*.rendered.yaml`, and apply them. The same pattern repeats across every category, so once you've read one component the rest are familiar.
+
+See [Configuration](../reference/configuration.md) for the full schema.
+
+## Deployment shapes
+
+- **Demo setup** — `./cli demo-setup` deploys the curated stack in parallel with explicit dependency ordering (e.g. `openwebui` waits for `litellm`). See [Quick Start](../getting-started/quick-start.md).
+- **Interactive setup** — `./cli interactive-setup` lets you pick components per category. Both produce the same cluster shape.
+
+[:octicons-arrow-right-24: Use Cases](use-cases.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Get Started](get-started.md){ .md-button }

--- a/docs/flex-ai/get-started.ko.md
+++ b/docs/flex-ai/get-started.ko.md
@@ -52,7 +52,7 @@ title: Get Started
 
 먼저 톤과 범위를 확인하고 싶다면:
 
-1. [Why Flex AI](why.ko.md) — 가치 제안과 5가지 유연성.
+1. [Why Flexible AI](why.ko.md) — 가치 제안과 5가지 유연성.
 2. [Architecture](architecture.ko.md) — 빌딩 블록과 계층 구조.
 3. [Components Overview](../components/index.md) — 25+ 컴포넌트 카탈로그.
 4. [Use Cases](use-cases.ko.md) — 5가지 시나리오와 베네핏.
@@ -96,7 +96,7 @@ npm install
 # Customer Stories
 
 !!! info "곧 공개 예정"
-    Flex AI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.
+    Flexible AI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.
 
 # 문의하기
 

--- a/docs/flex-ai/get-started.ko.md
+++ b/docs/flex-ai/get-started.ko.md
@@ -1,0 +1,108 @@
+---
+title: Get Started
+---
+
+[한국어](get-started.ko.md){ .md-button .md-button--primary } [English](get-started.md){ .md-button }
+
+# Offerings
+
+아키텍처를 처음부터 구축하는 환경부터, 이미 갖추고 있지만 고도화를 원하는 환경까지 — 모든 단계에 맞춘 아키텍처와 지원 체계, 스타터 킷을 제공합니다.
+
+<div class="grid cards" markdown>
+
+-   :material-pillar:{ .lg .middle } **Baseline for Building Full-stack AI Platform**
+
+    ---
+
+    - GPU + 오픈소스 프레임워크 + AWS 서비스 조합 사전 검증된 **레퍼런스 아키텍처**
+    - 다양한 use case와 배포 옵션을 위한 유연·확장 가능 디자인 패턴
+    - 모델·에이전트에 대한 **통합 액세스 셀프 서비스 포털**
+
+-   :material-handshake-outline:{ .lg .middle } **White-glove Support**
+
+    ---
+
+    - **AWS Specialist 기술 가이던스**: Compute, Kubernetes, Storage 등 전 영역
+    - 프로덕션 환경에서 GPU 가치 극대화 위한 베스트 프랙티스
+    - AWS, 온프레미스, 엣지 전반의 배포 지원
+
+-   :material-shopping-outline:{ .lg .middle } **Open-source via AWS Marketplace**
+
+    ---
+
+    - OSS 전문가가 사전 구성·최적화한 스택
+    - **1-Click Launch**로 AMI 즉시 배포 (이종 소스 통합 코드 작성 스킵)
+    - 보안·거버넌스 강화 Enterprise Edition 또는 BYOL 옵션
+
+-   :material-toolbox-outline:{ .lg .middle } **Production-ready Starter Kit**
+
+    ---
+
+    - 엔터프라이즈 AI 배포를 가속하는 **GenAI 인프라 툴킷**
+    - AI Gateway, LLM Serving, Vector DB, Embedding Models, E2E Observability 포함
+    - **박스 오픈 즉시** 프로덕션 환경에 적용 가능
+
+</div>
+
+# 즉시 시작하기
+
+스타터 킷은 이 리포지토리에서 바로 사용할 수 있습니다. 세 가지 진입점을 제공합니다.
+
+## Path 1 — 문서 읽기
+
+먼저 톤과 범위를 확인하고 싶다면:
+
+1. [Why Flex AI](why.ko.md) — 가치 제안과 5가지 유연성.
+2. [Architecture](architecture.ko.md) — 빌딩 블록과 계층 구조.
+3. [Components Overview](../components/index.md) — 25+ 컴포넌트 카탈로그.
+4. [Use Cases](use-cases.ko.md) — 5가지 시나리오와 베네핏.
+
+클러스터 없이 가능합니다.
+
+## Path 2 — 데모 실행
+
+AWS 계정과 [Prerequisites](../getting-started/prerequisites.md)에 명시된 도구가 준비되어 있으면 바로 시작할 수 있습니다.
+
+```bash
+# 1. 의존성 설치
+npm install
+
+# 2. 환경 구성 (.env.local 생성)
+./cli configure
+
+# 3. 인프라 + 큐레이션 스택 병렬 배포
+./cli demo-setup
+```
+
+옵션 플래그:
+
+```bash
+./cli --parallelism 6 demo-setup   # 병렬 설치 동시성 상향
+./cli --sequential   demo-setup    # 레거시 순차 동작
+```
+
+정리는 `./cli cleanup-everything`.
+
+## Path 3 — 워크샵
+
+`workshops/eks-genai-workshop/` 의 **Workshop Studio 워크샵**은 세 모듈로 구성됩니다.
+
+1. **Module 1** — 모델과 상호작용 (게이트웨이 + Open WebUI).
+2. **Module 2** — GenAI 컴포넌트 추가 (Vector DB, Observability, Guardrails).
+3. **Module 3** — 에이전틱 애플리케이션 구축 (Loan Buddy).
+
+자세한 진행 가이드는 [`workshops/eks-genai-workshop/README.md`](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/blob/main/workshops/eks-genai-workshop/README.md).
+
+# Customer Stories
+
+!!! info "곧 공개 예정"
+    Flex AI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.
+
+# 문의하기
+
+솔루션 도입에 관심이 있으신 분들은 아래 채널로 연락 부탁드립니다.
+
+- **GitHub Issues / Discussions** — [aws-samples/sample-genai-on-eks-starter-kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues)
+- **AWS Korea Specialist 팀**과의 직접 미팅이 필요하다면, 담당 AWS 어카운트 매니저(SA / TAM)를 통해 문의해 주세요.
+
+기여나 PR도 환영합니다 — [Contributing Guide](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/blob/main/CONTRIBUTING.md).

--- a/docs/flex-ai/get-started.md
+++ b/docs/flex-ai/get-started.md
@@ -1,0 +1,108 @@
+---
+title: Get Started
+---
+
+[한국어](get-started.ko.md){ .md-button } [English](get-started.md){ .md-button .md-button--primary }
+
+# Offerings
+
+Whether you are building from scratch or hardening an existing environment, Flex AI offers an architecture, support model, and starter kit for every stage.
+
+<div class="grid cards" markdown>
+
+-   :material-pillar:{ .lg .middle } **Baseline for Building Full-stack AI Platform**
+
+    ---
+
+    - Pre-validated **reference architectures** combining GPUs, OSS frameworks, and AWS services
+    - Flexible, scalable design patterns covering many use cases and deployment options
+    - **Self-service portal** for unified model and agent access
+
+-   :material-handshake-outline:{ .lg .middle } **White-glove Support**
+
+    ---
+
+    - **AWS specialist guidance** across compute, Kubernetes, storage, and more
+    - Best practices to maximize GPU value in production
+    - Deployment support across AWS, on-premises, and edge
+
+-   :material-shopping-outline:{ .lg .middle } **Open-source via AWS Marketplace**
+
+    ---
+
+    - OSS stacks pre-configured and optimized by experts
+    - **1-click launch** AMIs — skip the integration code
+    - Enterprise Edition with hardened security and governance, or BYOL options
+
+-   :material-toolbox-outline:{ .lg .middle } **Production-ready Starter Kit**
+
+    ---
+
+    - GenAI infrastructure toolkit that accelerates enterprise AI deployment
+    - AI Gateway, LLM serving, vector DB, embedding models, and E2E observability included
+    - **Production-ready out of the box**
+
+</div>
+
+# Start now
+
+The starter kit is ready to use directly from this repository. Three on-ramps:
+
+## Path 1 — Read the docs
+
+Skim before installing anything:
+
+1. [Why Flex AI](why.md) — value proposition and the five flexibility dimensions.
+2. [Architecture](architecture.md) — building blocks and the layered stack.
+3. [Components Overview](../components/index.md) — 25+ component catalog.
+4. [Use Cases](use-cases.md) — five scenarios and benefits.
+
+No cluster required.
+
+## Path 2 — Run the demo
+
+If you have an AWS account and the tools listed in [Prerequisites](../getting-started/prerequisites.md), start here:
+
+```bash
+# 1. Install dependencies
+npm install
+
+# 2. Configure environment (writes .env.local)
+./cli configure
+
+# 3. Provision infra and deploy the curated stack in parallel
+./cli demo-setup
+```
+
+Optional flags:
+
+```bash
+./cli --parallelism 6 demo-setup   # raise install concurrency
+./cli --sequential   demo-setup    # legacy serial behavior
+```
+
+Tear it down with `./cli cleanup-everything`.
+
+## Path 3 — Take the workshop
+
+The Workshop Studio workshop under `workshops/eks-genai-workshop/` runs three modules:
+
+1. **Module 1** — interacting with models (gateway + Open WebUI).
+2. **Module 2** — adding GenAI components (vector DB, observability, guardrails).
+3. **Module 3** — building and deploying an agentic application (Loan Buddy).
+
+Delivery instructions live in [`workshops/eks-genai-workshop/README.md`](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/blob/main/workshops/eks-genai-workshop/README.md).
+
+# Customer Stories
+
+!!! info "Coming soon"
+    Stories from customers redefining their AI infrastructure strategy with the Flex AI approach will land here shortly.
+
+# Get in touch
+
+If you'd like to discuss adoption, please reach out via:
+
+- **GitHub Issues / Discussions** — [aws-samples/sample-genai-on-eks-starter-kit](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues)
+- For a direct meeting with the AWS Korea specialist team, please go through your AWS account team (SA / TAM).
+
+Contributions and PRs are welcome — see the [Contributing Guide](https://github.com/aws-samples/sample-genai-on-eks-starter-kit/blob/main/CONTRIBUTING.md).

--- a/docs/flex-ai/get-started.md
+++ b/docs/flex-ai/get-started.md
@@ -6,7 +6,7 @@ title: Get Started
 
 # Offerings
 
-Whether you are building from scratch or hardening an existing environment, Flex AI offers an architecture, support model, and starter kit for every stage.
+Whether you are building from scratch or hardening an existing environment, Flexible AI offers an architecture, support model, and starter kit for every stage.
 
 <div class="grid cards" markdown>
 
@@ -52,7 +52,7 @@ The starter kit is ready to use directly from this repository. Three on-ramps:
 
 Skim before installing anything:
 
-1. [Why Flex AI](why.md) — value proposition and the five flexibility dimensions.
+1. [Why Flexible AI](why.md) — value proposition and the five flexibility dimensions.
 2. [Architecture](architecture.md) — building blocks and the layered stack.
 3. [Components Overview](../components/index.md) — 25+ component catalog.
 4. [Use Cases](use-cases.md) — five scenarios and benefits.
@@ -96,7 +96,7 @@ Delivery instructions live in [`workshops/eks-genai-workshop/README.md`](https:/
 # Customer Stories
 
 !!! info "Coming soon"
-    Stories from customers redefining their AI infrastructure strategy with the Flex AI approach will land here shortly.
+    Stories from customers redefining their AI infrastructure strategy with the Flexible AI approach will land here shortly.
 
 # Get in touch
 

--- a/docs/flex-ai/index.ko.md
+++ b/docs/flex-ai/index.ko.md
@@ -1,0 +1,80 @@
+---
+title: Flex AI 개요
+---
+
+[한국어](index.ko.md){ .md-button .md-button--primary } [English](index.md){ .md-button }
+
+# Architecting Flexible AI Platform on AWS
+
+> **Run Any Model, Anywhere.** 유연성(Flexibility), 주권(Sovereignty), 그리고 세밀한 제어(Granular Control)를 갖춘 차세대 AI 플랫폼.
+
+AI를 프로덕션에서 운영하는 기업들은 공통된 과제에 직면합니다.
+
+- "새로운 모델이 매주 쏟아지는데, 기존 파이프라인에 적용하려면 매번 재작업이 필요하다"
+- "사업부·팀마다 GPU를 따로 쓰고 모델을 개별 배포하다 보니, 전사 차원의 비용 가시성과 통합 관리가 불가능하다"
+- "API 기반 모델 호출 비용이 통제 불가능한 속도로 증가하고 있다"
+- "클라우드로 확장하고 싶지만, 그동안 투자해 온 온프레미스 GPU 자산도 함께 활용해야 한다"
+
+**Flexible AI Platform on AWS**는 이러한 프로덕션 환경의 현실적 과제를 정면으로 해결하기 위해 설계된 통합 AI 플랫폼 솔루션입니다.
+
+AWS의 **핵심 인프라 서비스**(Graviton, GPU/Trainium/Inferentia, EKS, S3 Vectors 등)와 **검증된 오픈소스 기술**(LangGraph, Mem0, LiteLLM, Langfuse, vLLM, Qwen 등)을 유기적으로 결합하여, 고객이 원하는 모델과 프레임워크를 자유롭게 선택하고, 데이터 파이프라인부터 모델 학습·서빙, 에이전틱 애플리케이션까지 아우르는 풀스택 AI 플랫폼을 단일 환경에서 일관되게 구축·운영할 수 있도록 사전 검증된 레퍼런스 아키텍처와 도입 가이던스를 제공합니다.
+
+## 핵심 기술 스택
+
+`LangGraph` · `LiteLLM` · `vLLM` · `Langfuse` · `Qwen` · `Mem0` · `EKS` · `Graviton` · `Inferentia/Trainium` · `S3 Vectors`
+
+## Run Any Model, Anywhere
+
+세 축의 결합이 Flex AI의 정체성입니다.
+
+<div class="grid cards" markdown>
+
+-   :material-cloud-outline:{ .lg .middle } **AWS Services**
+
+    ---
+
+    Graviton, GPU, Trainium/Inferentia, EKS, S3 Vectors 등 AWS의 검증된 인프라 서비스 위에서 동작합니다.
+
+-   :material-source-branch:{ .lg .middle } **Open-source Frameworks & Models**
+
+    ---
+
+    LangGraph, LiteLLM, Langfuse, vLLM, Qwen 등 검증된 오픈소스 생태계와 자유롭게 조합합니다.
+
+-   :material-server-network:{ .lg .middle } **Deployment Options**
+
+    ---
+
+    AWS Cloud, 온프레미스, Edge — 동일한 아키텍처 패턴으로 어디든 배포합니다.
+
+</div>
+
+## 어디로 갈까
+
+<div class="grid cards" markdown>
+
+-   :material-help-circle-outline:{ .lg .middle } **Why Flex AI**
+
+    ---
+
+    [:octicons-arrow-right-24: Value Proposition](why.ko.md)
+
+-   :material-sitemap-outline:{ .lg .middle } **Architecture**
+
+    ---
+
+    [:octicons-arrow-right-24: 5가지 차원의 유연성과 빌딩 블록](architecture.ko.md)
+
+-   :material-flask-outline:{ .lg .middle } **Use Cases**
+
+    ---
+
+    [:octicons-arrow-right-24: Key Use Cases & Benefits](use-cases.ko.md)
+
+-   :material-play-circle-outline:{ .lg .middle } **Get Started**
+
+    ---
+
+    [:octicons-arrow-right-24: Offerings & Contact](get-started.ko.md)
+
+</div>

--- a/docs/flex-ai/index.ko.md
+++ b/docs/flex-ai/index.ko.md
@@ -1,5 +1,5 @@
 ---
-title: Flex AI 개요
+title: Flexible AI 개요
 ---
 
 [한국어](index.ko.md){ .md-button .md-button--primary } [English](index.md){ .md-button }
@@ -25,7 +25,7 @@ AWS의 **핵심 인프라 서비스**(Graviton, GPU/Trainium/Inferentia, EKS, S3
 
 ## Run Any Model, Anywhere
 
-세 축의 결합이 Flex AI의 정체성입니다.
+세 축의 결합이 Flexible AI의 정체성입니다.
 
 <div class="grid cards" markdown>
 
@@ -53,7 +53,7 @@ AWS의 **핵심 인프라 서비스**(Graviton, GPU/Trainium/Inferentia, EKS, S3
 
 <div class="grid cards" markdown>
 
--   :material-help-circle-outline:{ .lg .middle } **Why Flex AI**
+-   :material-help-circle-outline:{ .lg .middle } **Why Flexible AI**
 
     ---
 

--- a/docs/flex-ai/index.md
+++ b/docs/flex-ai/index.md
@@ -1,5 +1,5 @@
 ---
-title: Flex AI Overview
+title: Flexible AI Overview
 ---
 
 [한국어](index.ko.md){ .md-button } [English](index.md){ .md-button .md-button--primary }
@@ -15,7 +15,7 @@ Teams running AI in production keep hitting the same wall:
 - "API-based model spend is growing faster than we can control."
 - "We want to scale into the cloud, but we also need to keep getting value out of the on-prem GPUs we already paid for."
 
-**Flexible AI Platform on AWS** — Flex AI for short — is the integrated answer to those production realities.
+**Flexible AI Platform on AWS** — Flexible AI for short — is the integrated answer to those production realities.
 
 It composes AWS's **core infrastructure** (Graviton, GPU, Trainium / Inferentia, EKS, S3 Vectors) with **proven open-source components** (LangGraph, Mem0, LiteLLM, Langfuse, vLLM, Qwen, …) so customers can pick the models and frameworks they want and run a full-stack AI platform — data pipelines, training, serving, agentic applications — coherently in one environment, on top of pre-validated reference architectures and adoption guidance.
 
@@ -25,7 +25,7 @@ It composes AWS's **core infrastructure** (Graviton, GPU, Trainium / Inferentia,
 
 ## Run Any Model, Anywhere
 
-Three axes meet in Flex AI:
+Three axes meet in Flexible AI:
 
 <div class="grid cards" markdown>
 
@@ -33,7 +33,7 @@ Three axes meet in Flex AI:
 
     ---
 
-    Graviton, GPU, Trainium / Inferentia, EKS, S3 Vectors — the AWS infrastructure surface Flex AI runs on.
+    Graviton, GPU, Trainium / Inferentia, EKS, S3 Vectors — the AWS infrastructure surface Flexible AI runs on.
 
 -   :material-source-branch:{ .lg .middle } **Open-source Frameworks & Models**
 
@@ -53,7 +53,7 @@ Three axes meet in Flex AI:
 
 <div class="grid cards" markdown>
 
--   :material-help-circle-outline:{ .lg .middle } **Why Flex AI**
+-   :material-help-circle-outline:{ .lg .middle } **Why Flexible AI**
 
     ---
 

--- a/docs/flex-ai/index.md
+++ b/docs/flex-ai/index.md
@@ -1,0 +1,80 @@
+---
+title: Flex AI Overview
+---
+
+[한국어](index.ko.md){ .md-button } [English](index.md){ .md-button .md-button--primary }
+
+# Architecting Flexible AI Platform on AWS
+
+> **Run Any Model, Anywhere.** A next-generation AI platform built on **flexibility**, **sovereignty**, and **granular control**.
+
+Teams running AI in production keep hitting the same wall:
+
+- "New models drop every week, but plugging them into our existing pipeline is rework every time."
+- "Each business unit runs its own GPUs and deploys models in isolation, so we have no enterprise-wide cost visibility or governance."
+- "API-based model spend is growing faster than we can control."
+- "We want to scale into the cloud, but we also need to keep getting value out of the on-prem GPUs we already paid for."
+
+**Flexible AI Platform on AWS** — Flex AI for short — is the integrated answer to those production realities.
+
+It composes AWS's **core infrastructure** (Graviton, GPU, Trainium / Inferentia, EKS, S3 Vectors) with **proven open-source components** (LangGraph, Mem0, LiteLLM, Langfuse, vLLM, Qwen, …) so customers can pick the models and frameworks they want and run a full-stack AI platform — data pipelines, training, serving, agentic applications — coherently in one environment, on top of pre-validated reference architectures and adoption guidance.
+
+## Core stack
+
+`LangGraph` · `LiteLLM` · `vLLM` · `Langfuse` · `Qwen` · `Mem0` · `EKS` · `Graviton` · `Inferentia/Trainium` · `S3 Vectors`
+
+## Run Any Model, Anywhere
+
+Three axes meet in Flex AI:
+
+<div class="grid cards" markdown>
+
+-   :material-cloud-outline:{ .lg .middle } **AWS Services**
+
+    ---
+
+    Graviton, GPU, Trainium / Inferentia, EKS, S3 Vectors — the AWS infrastructure surface Flex AI runs on.
+
+-   :material-source-branch:{ .lg .middle } **Open-source Frameworks & Models**
+
+    ---
+
+    LangGraph, LiteLLM, Langfuse, vLLM, Qwen, and the rest of the OSS ecosystem — composable, swap-friendly, no vendor control plane.
+
+-   :material-server-network:{ .lg .middle } **Deployment Options**
+
+    ---
+
+    AWS Cloud, on-premises, edge — same architecture pattern, deploy anywhere.
+
+</div>
+
+## Where to next
+
+<div class="grid cards" markdown>
+
+-   :material-help-circle-outline:{ .lg .middle } **Why Flex AI**
+
+    ---
+
+    [:octicons-arrow-right-24: Value Proposition](why.md)
+
+-   :material-sitemap-outline:{ .lg .middle } **Architecture**
+
+    ---
+
+    [:octicons-arrow-right-24: Five dimensions of flexibility & building blocks](architecture.md)
+
+-   :material-flask-outline:{ .lg .middle } **Use Cases**
+
+    ---
+
+    [:octicons-arrow-right-24: Key use cases & benefits](use-cases.md)
+
+-   :material-play-circle-outline:{ .lg .middle } **Get Started**
+
+    ---
+
+    [:octicons-arrow-right-24: Offerings & contact](get-started.md)
+
+</div>

--- a/docs/flex-ai/landing.en.html
+++ b/docs/flex-ai/landing.en.html
@@ -232,7 +232,7 @@
   }
   .flex-card p { font-size: 12px; color: var(--aws-muted); line-height: 1.6; }
 
-  /* FUNCTIONAL VIEW - placeholder */
+  /* FUNCTIONAL VIEW */
   #functional { background: var(--aws-dark); }
   .image-placeholder {
     background: var(--aws-navy);
@@ -245,6 +245,19 @@
   }
   .image-placeholder-icon { font-size: 48px; opacity: 0.5; }
   .image-placeholder-text { font-size: 14px; font-family: var(--font-display); letter-spacing: 0.05em; }
+  .arch-diagram {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px;
+    padding: 24px;
+    overflow: hidden;
+  }
+  .arch-diagram svg { width: 100%; height: auto; display: block; }
+  .arch-caption {
+    margin-top: 16px; text-align: center;
+    font-family: var(--font-display); font-size: 11px; letter-spacing: 0.08em;
+    color: var(--aws-muted); text-transform: uppercase;
+  }
 
   /* BENEFITS */
   #benefits {
@@ -636,10 +649,200 @@
     <h2 class="section-title">Functional View & Building Blocks</h2>
     <p class="section-desc">From the application layer down to cloud, on-premises, and edge infrastructure — Flexible AI spans every layer. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.</p>
   </div>
-  <div class="image-placeholder reveal">
-    <div class="image-placeholder-icon">🖼️</div>
-    <div class="image-placeholder-text">[ Diagram placeholder ]</div>
-    <div class="image-placeholder-text" style="font-size: 12px; opacity: 0.6;">A reference architecture image will live here</div>
+  <div class="arch-diagram reveal">
+    <svg viewBox="0 0 1400 940" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Flexible AI layered architecture diagram">
+      <defs>
+        <linearGradient id="layerOrange" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#FF9900" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#FF9900" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#4A9EE7" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#4A9EE7" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerPurple" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#A78BFA" stop-opacity="0.10"/>
+          <stop offset="100%" stop-color="#A78BFA" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerGreen" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#34D399" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#34D399" stop-opacity="0.02"/>
+        </linearGradient>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#8BA3BE"/>
+        </marker>
+      </defs>
+
+      <style>
+        .layer-label { font-family: 'DM Mono', monospace; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; }
+        .node-title { font-family: 'Inter', sans-serif; font-size: 13px; font-weight: 700; fill: #E8EFF7; }
+        .node-sub { font-family: 'Inter', sans-serif; font-size: 10px; fill: #8BA3BE; }
+        .node-rect { fill: #1A2B45; stroke: rgba(255,255,255,0.12); stroke-width: 1; rx: 8; ry: 8; }
+        .node-rect.orange { stroke: rgba(255,153,0,0.45); }
+        .node-rect.blue { stroke: rgba(74,158,231,0.45); }
+        .node-rect.purple { stroke: rgba(167,139,250,0.45); }
+        .node-rect.green { stroke: rgba(52,211,153,0.45); }
+        .flow { stroke: #8BA3BE; stroke-width: 1.2; fill: none; opacity: 0.55; }
+      </style>
+
+      <!-- Layer 1 - Users & Clients (top) -->
+      <rect x="40" y="30" width="1320" height="110" fill="url(#layerOrange)" rx="12" ry="12"/>
+      <text x="60" y="55" class="layer-label" fill="#FF9900">USERS &amp; CLIENTS</text>
+      <g transform="translate(80,75)">
+        <rect class="node-rect orange" width="240" height="50"/>
+        <text x="20" y="22" class="node-title">Open WebUI</text>
+        <text x="20" y="38" class="node-sub">Self-service portal · Chat UI</text>
+      </g>
+      <g transform="translate(360,75)">
+        <rect class="node-rect orange" width="280" height="50"/>
+        <text x="20" y="22" class="node-title">Custom Apps &amp; Agents</text>
+        <text x="20" y="38" class="node-sub">SDK / API consumers</text>
+      </g>
+      <g transform="translate(680,75)">
+        <rect class="node-rect orange" width="220" height="50"/>
+        <text x="20" y="22" class="node-title">Workflow Automation</text>
+        <text x="20" y="38" class="node-sub">n8n</text>
+      </g>
+      <g transform="translate(940,75)">
+        <rect class="node-rect orange" width="380" height="50"/>
+        <text x="20" y="22" class="node-title">Workshop / Reference</text>
+        <text x="20" y="38" class="node-sub">eks-genai-workshop · Loan Buddy</text>
+      </g>
+
+      <!-- Layer 2 - Gateway & Guardrails -->
+      <rect x="40" y="170" width="1320" height="110" fill="url(#layerBlue)" rx="12" ry="12"/>
+      <text x="60" y="195" class="layer-label" fill="#4A9EE7">GATEWAY &amp; GUARDRAILS</text>
+      <g transform="translate(80,215)">
+        <rect class="node-rect blue" width="380" height="50"/>
+        <text x="20" y="22" class="node-title">AI Gateway</text>
+        <text x="20" y="38" class="node-sub">LiteLLM · Kong AI Gateway OSS</text>
+      </g>
+      <g transform="translate(500,215)">
+        <rect class="node-rect blue" width="260" height="50"/>
+        <text x="20" y="22" class="node-title">Guardrails</text>
+        <text x="20" y="38" class="node-sub">Guardrails AI</text>
+      </g>
+      <g transform="translate(800,215)">
+        <rect class="node-rect blue" width="520" height="50"/>
+        <text x="20" y="22" class="node-title">Routing &amp; Policy</text>
+        <text x="20" y="38" class="node-sub">Workload-optimized routing · Centralized policy management</text>
+      </g>
+
+      <!-- Layer 3 - Agentic Layer -->
+      <rect x="40" y="310" width="1320" height="140" fill="url(#layerPurple)" rx="12" ry="12"/>
+      <text x="60" y="335" class="layer-label" fill="#A78BFA">AGENTIC LAYER</text>
+      <g transform="translate(80,355)">
+        <rect class="node-rect purple" width="320" height="80"/>
+        <text x="20" y="24" class="node-title">Agent Frameworks</text>
+        <text x="20" y="42" class="node-sub">LangGraph · Strands · Agno</text>
+        <text x="20" y="58" class="node-sub">OpenClaw · Bedrock AgentCore</text>
+      </g>
+      <g transform="translate(440,355)">
+        <rect class="node-rect purple" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">MCP / A2A</text>
+        <text x="20" y="42" class="node-sub">FastMCP 2.0</text>
+        <text x="20" y="58" class="node-sub">Tool servers · Agent-to-agent</text>
+      </g>
+      <g transform="translate(720,355)">
+        <rect class="node-rect purple" width="320" height="80"/>
+        <text x="20" y="24" class="node-title">Retrieval &amp; Memory</text>
+        <text x="20" y="42" class="node-sub">Qdrant · Chroma · Milvus</text>
+        <text x="20" y="58" class="node-sub">S3 Vectors · Mem0</text>
+      </g>
+      <g transform="translate(1080,355)">
+        <rect class="node-rect purple" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">Reference Apps</text>
+        <text x="20" y="42" class="node-sub">Calculator agents</text>
+        <text x="20" y="58" class="node-sub">DevOps / Doc Writer</text>
+      </g>
+
+      <!-- Layer 4 - Model Serving -->
+      <rect x="40" y="480" width="1320" height="140" fill="url(#layerOrange)" rx="12" ry="12"/>
+      <text x="60" y="505" class="layer-label" fill="#FF9900">MODEL SERVING</text>
+      <g transform="translate(80,525)">
+        <rect class="node-rect orange" width="340" height="80"/>
+        <text x="20" y="24" class="node-title">Self-hosted LLM</text>
+        <text x="20" y="42" class="node-sub">vLLM · SGLang · TGI · Ollama</text>
+        <text x="20" y="58" class="node-sub">Ray · NVIDIA Dynamo Platform</text>
+      </g>
+      <g transform="translate(460,525)">
+        <rect class="node-rect orange" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">Embedding</text>
+        <text x="20" y="42" class="node-sub">Text Embedding Inference</text>
+        <text x="20" y="58" class="node-sub">(TEI)</text>
+      </g>
+      <g transform="translate(740,525)">
+        <rect class="node-rect orange" width="280" height="80"/>
+        <text x="20" y="24" class="node-title">AWS Managed</text>
+        <text x="20" y="42" class="node-sub">Amazon Bedrock</text>
+        <text x="20" y="58" class="node-sub">Nova · SageMaker</text>
+      </g>
+      <g transform="translate(1060,525)">
+        <rect class="node-rect orange" width="260" height="80"/>
+        <text x="20" y="24" class="node-title">External LLM</text>
+        <text x="20" y="42" class="node-sub">OpenAI · Anthropic</text>
+        <text x="20" y="58" class="node-sub">Gemini · others</text>
+      </g>
+
+      <!-- Layer 5 - Observability -->
+      <rect x="40" y="650" width="1320" height="80" fill="url(#layerGreen)" rx="12" ry="12"/>
+      <text x="60" y="675" class="layer-label" fill="#34D399">OBSERVABILITY</text>
+      <g transform="translate(80,690)">
+        <rect class="node-rect green" width="380" height="30"/>
+        <text x="20" y="20" class="node-title">Langfuse</text>
+        <text x="160" y="20" class="node-sub">tracing · session/tag</text>
+      </g>
+      <g transform="translate(500,690)">
+        <rect class="node-rect green" width="380" height="30"/>
+        <text x="20" y="20" class="node-title">Phoenix</text>
+        <text x="160" y="20" class="node-sub">evaluation · monitoring</text>
+      </g>
+      <g transform="translate(920,690)">
+        <rect class="node-rect green" width="400" height="30"/>
+        <text x="20" y="20" class="node-title">MLflow</text>
+        <text x="160" y="20" class="node-sub">experiment tracking</text>
+      </g>
+
+      <!-- Layer 6 - Compute & Infrastructure -->
+      <rect x="40" y="760" width="1320" height="160" fill="url(#layerBlue)" rx="12" ry="12"/>
+      <text x="60" y="785" class="layer-label" fill="#4A9EE7">COMPUTE &amp; INFRASTRUCTURE</text>
+      <g transform="translate(80,805)">
+        <rect class="node-rect blue" width="300" height="100"/>
+        <text x="20" y="24" class="node-title">Amazon EKS</text>
+        <text x="20" y="42" class="node-sub">Auto Mode · Standard</text>
+        <text x="20" y="58" class="node-sub">EKS Hybrid Node (on-prem)</text>
+        <text x="20" y="78" class="node-sub">Karpenter · NodePool</text>
+      </g>
+      <g transform="translate(420,805)">
+        <rect class="node-rect blue" width="300" height="100"/>
+        <text x="20" y="24" class="node-title">Heterogeneous Compute</text>
+        <text x="20" y="42" class="node-sub">GPU (g6e · g6 · g5g)</text>
+        <text x="20" y="58" class="node-sub">Trainium / Inferentia (inf2 · trn1)</text>
+        <text x="20" y="78" class="node-sub">Graviton (planning · CPU)</text>
+      </g>
+      <g transform="translate(760,805)">
+        <rect class="node-rect blue" width="280" height="100"/>
+        <text x="20" y="24" class="node-title">Storage &amp; Networking</text>
+        <text x="20" y="42" class="node-sub">EFS model cache · S3 Vectors</text>
+        <text x="20" y="58" class="node-sub">ALB Ingress + ACM</text>
+        <text x="20" y="78" class="node-sub">VPC · Private subnets</text>
+      </g>
+      <g transform="translate(1080,805)">
+        <rect class="node-rect blue" width="240" height="100"/>
+        <text x="20" y="24" class="node-title">Identity &amp; Secrets</text>
+        <text x="20" y="42" class="node-sub">IAM Roles for SA (IRSA)</text>
+        <text x="20" y="58" class="node-sub">AWS Secrets Manager</text>
+        <text x="20" y="78" class="node-sub">ECR + pull-through cache</text>
+      </g>
+
+      <!-- Vertical flow lines between layers -->
+      <line x1="700" y1="140" x2="700" y2="170" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="280" x2="700" y2="310" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="450" x2="700" y2="480" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="620" x2="700" y2="650" class="flow" marker-end="url(#arrow)" stroke-dasharray="4 4"/>
+      <line x1="700" y1="730" x2="700" y2="760" class="flow" stroke-dasharray="4 4"/>
+    </svg>
+    <div class="arch-caption">Built from the components in this repository · pick one or compose per category</div>
   </div>
 </section>
 

--- a/docs/flex-ai/landing.en.html
+++ b/docs/flex-ai/landing.en.html
@@ -588,7 +588,7 @@
   <div class="reveal">
     <div class="section-label">FLEXIBLE FROM ALL ANGLES</div>
     <h2 class="section-title">Five Dimensions of Flexibility</h2>
-    <p class="section-desc">Flex AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, switch on the relevant axis instead of redesigning the whole architecture.</p>
+    <p class="section-desc">Flexible AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, switch on the relevant axis instead of redesigning the whole architecture.</p>
   </div>
   <div class="flex-grid">
     <div class="flex-card reveal">
@@ -634,7 +634,7 @@
   <div class="reveal">
     <div class="section-label">FUNCTIONAL VIEW & BUILDING BLOCKS</div>
     <h2 class="section-title">Functional View & Building Blocks</h2>
-    <p class="section-desc">From the application layer down to cloud, on-premises, and edge infrastructure — Flex AI spans every layer. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.</p>
+    <p class="section-desc">From the application layer down to cloud, on-premises, and edge infrastructure — Flexible AI spans every layer. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.</p>
   </div>
   <div class="image-placeholder reveal">
     <div class="image-placeholder-icon">🖼️</div>
@@ -732,7 +732,7 @@
   <div class="reveal">
     <div class="section-label">OFFERINGS</div>
     <h2 class="section-title">Offerings</h2>
-    <p class="section-desc">Whether you are building from scratch or hardening an existing environment, Flex AI offers an architecture, support model, and starter kit for every stage.</p>
+    <p class="section-desc">Whether you are building from scratch or hardening an existing environment, Flexible AI offers an architecture, support model, and starter kit for every stage.</p>
   </div>
   <div class="offering-grid">
     <div class="offering-card reveal">
@@ -779,7 +779,7 @@
   <div class="reveal">
     <div class="section-label">CUSTOMER STORIES</div>
     <h2 class="section-title">Customer Stories</h2>
-    <p class="section-desc">Stories from customers redefining their AI infrastructure strategy with the Flex AI approach are coming soon.</p>
+    <p class="section-desc">Stories from customers redefining their AI infrastructure strategy with the Flexible AI approach are coming soon.</p>
   </div>
   <div class="customers-placeholder reveal">
     <div class="image-placeholder-icon">📋</div>
@@ -793,7 +793,7 @@
     <div class="contact-info reveal">
       <div class="section-label">GET IN TOUCH</div>
       <h2>Contact us</h2>
-      <p>If you are interested in Flex AI, reach out via the channels below or work with your AWS account team (SA / TAM).</p>
+      <p>If you are interested in Flexible AI, reach out via the channels below or work with your AWS account team (SA / TAM).</p>
       <div class="contact-emails">
         <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
           <span class="contact-email-icon">🐙</span>

--- a/docs/flex-ai/landing.en.html
+++ b/docs/flex-ai/landing.en.html
@@ -1,0 +1,854 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecting Flexible AI Platform on AWS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;700;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --aws-orange: #FF9900;
+    --aws-orange-light: #FFB84D;
+    --aws-dark: #0D1117;
+    --aws-navy: #0F1B2D;
+    --aws-mid: #1A2B45;
+    --aws-border: rgba(255,153,0,0.2);
+    --aws-border-soft: rgba(255,255,255,0.08);
+    --aws-text: #E8EFF7;
+    --aws-muted: #8BA3BE;
+    --accent-blue: #4A9EE7;
+    --accent-purple: #A78BFA;
+    --accent-green: #34D399;
+    --font-display: 'DM Mono', monospace;
+    --font-body: 'Inter', sans-serif;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: var(--font-body);
+    background: var(--aws-dark);
+    color: var(--aws-text);
+    line-height: 1.7;
+    overflow-x: hidden;
+  }
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    background: rgba(13,17,23,0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--aws-border);
+    padding: 0 5%;
+    display: flex; align-items: center; justify-content: space-between;
+    height: 60px;
+  }
+  .nav-logo {
+    display: flex; align-items: center; gap: 10px;
+    font-family: var(--font-display); font-size: 13px; letter-spacing: 0.08em;
+    color: var(--aws-orange); text-decoration: none;
+  }
+  .nav-logo svg { width: 28px; height: 28px; }
+  .nav-links { display: flex; gap: 26px; list-style: none; }
+  .nav-links a {
+    color: var(--aws-muted); text-decoration: none;
+    font-size: 13px; letter-spacing: 0.04em;
+    transition: color 0.2s;
+  }
+  .nav-links a:hover { color: var(--aws-orange); }
+  .nav-cta {
+    background: var(--aws-orange); color: var(--aws-dark) !important;
+    padding: 7px 18px; border-radius: 4px;
+    font-weight: 700 !important; font-size: 13px !important;
+  }
+  .nav-cta:hover { background: var(--aws-orange-light) !important; color: var(--aws-dark) !important; }
+
+  .hero {
+    min-height: 100vh;
+    display: flex; align-items: center;
+    padding: 100px 5% 60px;
+    position: relative; overflow: hidden;
+  }
+  .hero-bg {
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(ellipse 80% 60% at 70% 50%, rgba(255,153,0,0.08) 0%, transparent 60%),
+      radial-gradient(ellipse 60% 80% at 20% 80%, rgba(74,158,231,0.05) 0%, transparent 60%),
+      linear-gradient(160deg, var(--aws-dark) 0%, var(--aws-navy) 100%);
+  }
+  .hero-grid {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(255,153,0,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,153,0,0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    mask-image: radial-gradient(ellipse 80% 80% at 60% 40%, black 0%, transparent 70%);
+  }
+  .hero-content { position: relative; z-index: 2; max-width: 880px; }
+  .hero h1 {
+    font-size: clamp(38px, 5.5vw, 68px);
+    font-weight: 900; line-height: 1.08;
+    letter-spacing: -0.025em; margin-bottom: 24px;
+    animation: fadeUp 0.6s 0.1s ease both;
+  }
+  .hero h1 .accent { color: var(--aws-orange); }
+  .hero-sub {
+    font-family: var(--font-display);
+    font-size: clamp(18px, 2.5vw, 28px);
+    color: var(--aws-orange);
+    letter-spacing: 0.04em; margin-bottom: 28px;
+    animation: fadeUp 0.6s 0.2s ease both;
+  }
+  .hero p {
+    font-size: 17px; color: var(--aws-muted);
+    max-width: 660px; margin-bottom: 40px;
+    animation: fadeUp 0.6s 0.3s ease both;
+  }
+  .hero-actions {
+    display: flex; gap: 16px; flex-wrap: wrap;
+    animation: fadeUp 0.6s 0.4s ease both;
+  }
+  .btn-primary {
+    background: var(--aws-orange); color: var(--aws-dark);
+    padding: 14px 32px; border-radius: 4px;
+    font-weight: 700; font-size: 15px; text-decoration: none;
+    border: none; cursor: pointer;
+    transition: background 0.2s, transform 0.15s;
+    display: inline-flex; align-items: center; gap: 8px;
+  }
+  .btn-primary:hover { background: var(--aws-orange-light); transform: translateY(-1px); }
+  .btn-outline {
+    background: transparent; color: var(--aws-text);
+    padding: 14px 32px; border-radius: 4px;
+    font-weight: 500; font-size: 15px; text-decoration: none;
+    border: 1px solid rgba(255,255,255,0.2); cursor: pointer;
+    transition: border-color 0.2s, color 0.2s, transform 0.15s;
+    display: inline-flex; align-items: center; gap: 8px;
+  }
+  .btn-outline:hover { border-color: var(--aws-orange); color: var(--aws-orange); transform: translateY(-1px); }
+
+  section { padding: 100px 5%; }
+  .section-label {
+    font-family: var(--font-display);
+    font-size: 11px; letter-spacing: 0.15em;
+    color: var(--aws-orange); text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+  .section-title {
+    font-size: clamp(28px, 3.5vw, 44px);
+    font-weight: 700; letter-spacing: -0.02em;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  .section-desc {
+    font-size: 16px; color: var(--aws-muted);
+    max-width: 720px; margin-bottom: 60px;
+  }
+
+  /* OVERVIEW */
+  #overview {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .overview-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; align-items: center; }
+  .overview-text p {
+    font-size: 16px; color: var(--aws-muted); line-height: 1.8;
+    margin-bottom: 20px;
+  }
+  .overview-text strong { color: var(--aws-text); }
+  .overview-text .quote-block strong { color: var(--accent-blue); }
+  .tech-pills { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+  .pill {
+    font-family: var(--font-display); font-size: 11px;
+    background: rgba(255,153,0,0.1);
+    border: 1px solid var(--aws-border);
+    color: var(--aws-orange);
+    padding: 6px 12px; border-radius: 20px;
+  }
+  .flex-circle {
+    position: relative; width: 100%;
+    aspect-ratio: 1; max-width: 480px; margin: 0 auto;
+  }
+  .flex-circle svg { width: 100%; height: 100%; }
+  .flex-tagline { text-align: center; margin-top: 24px; }
+  .flex-tagline-main { font-size: 28px; font-weight: 700; margin-bottom: 8px; }
+  .flex-tagline-main span { color: var(--aws-orange); }
+  .flex-tagline-sub { font-size: 14px; color: var(--aws-muted); }
+
+  /* VALUE PROPS */
+  #value { background: var(--aws-dark); }
+  .value-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
+  .value-card {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    position: relative; overflow: hidden;
+    transition: border-color 0.3s, transform 0.2s;
+  }
+  .value-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .value-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0;
+    height: 3px; background: var(--aws-orange);
+    transform: scaleX(0); transform-origin: left;
+    transition: transform 0.3s;
+  }
+  .value-card:hover::before { transform: scaleX(1); }
+  .value-icon {
+    width: 52px; height: 52px;
+    background: rgba(255,153,0,0.1);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 26px; margin-bottom: 20px;
+  }
+  .value-card h3 { font-size: 18px; font-weight: 700; margin-bottom: 12px; line-height: 1.3; }
+  .value-card p { font-size: 14px; color: var(--aws-muted); line-height: 1.7; }
+
+  /* FLEXIBILITY (5 dimensions) */
+  #flexibility {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .flex-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; }
+  .flex-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 10px; padding: 24px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .flex-card:hover { border-color: var(--aws-orange); transform: translateY(-3px); }
+  .flex-icon { font-size: 28px; margin-bottom: 14px; }
+  .flex-card h4 {
+    font-size: 15px; font-weight: 700; margin-bottom: 6px;
+    color: var(--aws-text); line-height: 1.3;
+  }
+  .flex-card .flex-en {
+    font-family: var(--font-display); font-size: 11px;
+    color: var(--accent-blue); margin-bottom: 14px;
+  }
+  .flex-card .flex-key {
+    font-size: 13px; color: var(--aws-orange); font-weight: 500;
+    margin-bottom: 12px; font-style: italic;
+  }
+  .flex-card p { font-size: 12px; color: var(--aws-muted); line-height: 1.6; }
+
+  /* FUNCTIONAL VIEW - placeholder */
+  #functional { background: var(--aws-dark); }
+  .image-placeholder {
+    background: var(--aws-navy);
+    border: 2px dashed var(--aws-border);
+    border-radius: 12px;
+    min-height: 480px;
+    display: flex; align-items: center; justify-content: center;
+    flex-direction: column; gap: 12px;
+    color: var(--aws-muted);
+  }
+  .image-placeholder-icon { font-size: 48px; opacity: 0.5; }
+  .image-placeholder-text { font-size: 14px; font-family: var(--font-display); letter-spacing: 0.05em; }
+
+  /* BENEFITS */
+  #benefits {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .benefits-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+  .benefit-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    position: relative; overflow: hidden;
+    transition: border-color 0.3s, transform 0.2s;
+  }
+  .benefit-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .benefit-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0;
+    height: 3px; transform: scaleX(0); transform-origin: left;
+    transition: transform 0.3s;
+  }
+  .benefit-card:hover::before { transform: scaleX(1); }
+  .benefit-card.b1::before { background: var(--accent-purple); }
+  .benefit-card.b2::before { background: var(--accent-green); }
+  .benefit-card.b3::before { background: var(--accent-blue); }
+  .benefit-card.b4::before { background: var(--aws-orange); }
+  .benefit-icon {
+    width: 48px; height: 48px;
+    border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 24px; margin-bottom: 20px;
+  }
+  .benefit-card.b1 .benefit-icon { background: rgba(167,139,250,0.15); }
+  .benefit-card.b2 .benefit-icon { background: rgba(52,211,153,0.15); }
+  .benefit-card.b3 .benefit-icon { background: rgba(74,158,231,0.15); }
+  .benefit-card.b4 .benefit-icon { background: rgba(255,153,0,0.15); }
+  .benefit-card h3 { font-size: 17px; font-weight: 700; margin-bottom: 16px; line-height: 1.3; }
+  .benefit-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+  .benefit-card li {
+    font-size: 13px; color: var(--aws-muted);
+    padding-left: 16px; position: relative; line-height: 1.6;
+  }
+  .benefit-card li::before {
+    content: '✓'; color: var(--aws-orange);
+    position: absolute; left: 0; font-weight: 700;
+  }
+
+  /* USE CASES */
+  #usecases { background: var(--aws-dark); }
+  .usecase-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; }
+  .usecase-card {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 28px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .usecase-card:hover { border-color: var(--aws-orange); transform: translateY(-3px); }
+  .usecase-num {
+    font-family: var(--font-display);
+    font-size: 28px; color: var(--aws-orange);
+    line-height: 1; margin-bottom: 16px; font-weight: 500;
+  }
+  .usecase-card h3 { font-size: 16px; font-weight: 700; margin-bottom: 12px; line-height: 1.35; }
+  .usecase-card p { font-size: 13px; color: var(--aws-muted); line-height: 1.65; }
+
+  /* OFFERINGS */
+  #offerings {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .offering-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+  .offering-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .offering-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .offering-icon {
+    width: 56px; height: 56px;
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 28px; margin-bottom: 20px;
+    background: linear-gradient(135deg, rgba(255,153,0,0.15), rgba(255,153,0,0.05));
+    border: 1px solid var(--aws-border);
+  }
+  .offering-card h3 {
+    font-size: 17px; font-weight: 700; margin-bottom: 16px;
+    color: var(--aws-orange); line-height: 1.3;
+  }
+  .offering-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+  .offering-card li {
+    font-size: 13px; color: var(--aws-muted);
+    padding-left: 14px; position: relative; line-height: 1.6;
+  }
+  .offering-card li::before {
+    content: '→'; color: var(--aws-orange);
+    position: absolute; left: 0;
+  }
+
+  /* CUSTOMER STORIES - empty placeholder */
+  #customers { background: var(--aws-dark); }
+  .customers-placeholder {
+    background: var(--aws-navy);
+    border: 2px dashed var(--aws-border);
+    border-radius: 12px;
+    min-height: 240px;
+    display: flex; align-items: center; justify-content: center;
+    flex-direction: column; gap: 12px;
+    color: var(--aws-muted);
+  }
+
+  /* CONTACT */
+  #contact {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+  }
+  .contact-layout {
+    display: grid; grid-template-columns: 1fr 1.2fr; gap: 80px; align-items: start;
+  }
+  .contact-info h2 { font-size: clamp(28px, 3.5vw, 40px); margin-bottom: 16px; }
+  .contact-info > p { font-size: 16px; color: var(--aws-muted); margin-bottom: 32px; }
+  .contact-emails { display: flex; flex-direction: column; gap: 12px; }
+  .contact-email {
+    display: flex; gap: 14px; align-items: center;
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 8px; padding: 16px 20px;
+    text-decoration: none; color: var(--aws-text);
+    transition: border-color 0.2s;
+  }
+  .contact-email:hover { border-color: var(--aws-orange); }
+  .contact-email-icon { font-size: 20px; }
+  .contact-email-text { font-size: 14px; font-weight: 500; font-family: var(--font-display); }
+
+  .contact-form-wrapper {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px; padding: 36px;
+  }
+  .form-title { font-size: 20px; font-weight: 700; margin-bottom: 24px; }
+  .form-group { margin-bottom: 20px; }
+  .form-group label {
+    display: block; font-size: 13px; color: var(--aws-muted);
+    margin-bottom: 8px;
+  }
+  .form-group input,
+  .form-group textarea {
+    width: 100%;
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 6px; padding: 12px 16px;
+    color: var(--aws-text); font-size: 14px;
+    font-family: var(--font-body);
+    transition: border-color 0.2s; outline: none;
+  }
+  .form-group input:focus,
+  .form-group textarea:focus { border-color: var(--aws-orange); }
+  .form-group textarea { resize: vertical; min-height: 100px; }
+  .form-submit {
+    width: 100%;
+    background: var(--aws-orange); color: var(--aws-dark);
+    padding: 14px; border-radius: 6px;
+    font-weight: 700; font-size: 15px;
+    border: none; cursor: pointer;
+    transition: background 0.2s;
+  }
+  .form-submit:hover { background: var(--aws-orange-light); }
+
+  footer {
+    background: var(--aws-dark);
+    border-top: 1px solid var(--aws-border);
+    padding: 32px 5%;
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 12px; color: var(--aws-muted); flex-wrap: wrap; gap: 16px;
+  }
+  .footer-logo { font-family: var(--font-display); font-size: 12px; }
+
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .reveal {
+    opacity: 0; transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+  .reveal.visible { opacity: 1; transform: translateY(0); }
+
+  @media (max-width: 1100px) {
+    .flex-grid { grid-template-columns: repeat(3, 1fr); }
+    .usecase-grid { grid-template-columns: repeat(3, 1fr); }
+    .benefits-grid, .offering-grid, .value-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 900px) {
+    .overview-layout, .contact-layout { grid-template-columns: 1fr; gap: 40px; }
+    nav .nav-links { display: none; }
+  }
+  @media (max-width: 600px) {
+    .flex-grid, .usecase-grid, .benefits-grid, .offering-grid, .value-grid { grid-template-columns: 1fr; }
+    section { padding: 60px 5%; }
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <a href="#" class="nav-logo">
+    <svg viewBox="0 0 40 40" fill="none">
+      <rect width="40" height="40" rx="6" fill="#FF9900" opacity="0.15"/>
+      <path d="M8 28C12 24 16 20 20 20C24 20 28 24 32 28" stroke="#FF9900" stroke-width="2" stroke-linecap="round"/>
+      <path d="M8 20C12 16 16 14 20 14C24 14 28 16 32 20" stroke="#FF9900" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+      <path d="M8 12C12 10 16 9 20 9C24 9 28 10 32 12" stroke="#FF9900" stroke-width="2" stroke-linecap="round" opacity="0.3"/>
+    </svg>
+    FLEXIBLE AI · AWS
+  </a>
+  <ul class="nav-links">
+    <li><a href="#overview">Overview</a></li>
+    <li><a href="#value">Value Proposition</a></li>
+    <li><a href="#flexibility">Flexibility</a></li>
+    <li><a href="#functional">Functional View</a></li>
+    <li><a href="#benefits">Benefits</a></li>
+    <li><a href="#usecases">Use Cases</a></li>
+    <li><a href="#offerings">Offerings</a></li>
+    <li><a href="#customers">Customers</a></li>
+    <li><a href="landing.html" title="한국어">KO</a></li>
+    <li><a href="../" title="Back to docs site">Docs</a></li>
+    <li><a href="#contact" class="nav-cta">Contact</a></li>
+  </ul>
+</nav>
+
+<section class="hero">
+  <div class="hero-bg"></div>
+  <div class="hero-grid"></div>
+  <div class="hero-content">
+    <h1>Architecting Flexible<br><span class="accent">AI Platform</span> on AWS</h1>
+    <div class="hero-sub">Run Any Model, Anywhere.</div>
+    <p>A next-generation AI platform built on flexibility, sovereignty, and granular control. Run any model, in any environment, composed to fit your business — not the other way around.</p>
+    <div class="hero-actions">
+      <a href="#overview" class="btn-primary">Explore the solution →</a>
+      <a href="#contact" class="btn-outline">Contact us</a>
+    </div>
+  </div>
+</section>
+
+<!-- 1. OVERVIEW -->
+<section id="overview">
+  <div class="overview-layout">
+    <div class="overview-text reveal">
+      <div class="section-label">OVERVIEW</div>
+      <p class="quote-block">Teams running AI in production keep hitting the same wall. <strong>"New models drop every week, but plugging them into our existing pipeline is rework every time."</strong> <strong>"Each business unit runs its own GPUs and deploys models in isolation — no enterprise-wide cost visibility or governance."</strong> <strong>"API-based model spend is growing faster than we can control."</strong> <strong>"We want to scale into the cloud, but we also need to keep getting value out of the on-prem GPUs we already paid for."</strong> — Flexible AI Platform on AWS is the integrated solution designed to take those production realities head-on.</p>
+      <p>It composes AWS's <strong>core infrastructure</strong> (Graviton, GPU / Trainium / Inferentia, EKS, S3 Vectors) with <strong>proven open-source components</strong> (LangGraph, Mem0, LiteLLM, Langfuse, vLLM, Qwen, …) so customers can pick the models and frameworks they want and run a coherent full-stack AI platform — data pipelines, training, serving, and agentic applications — on top of pre-validated reference architectures and adoption guidance.</p>
+      <div class="tech-pills">
+        <span class="pill">LangGraph</span>
+        <span class="pill">LiteLLM</span>
+        <span class="pill">vLLM</span>
+        <span class="pill">Langfuse</span>
+        <span class="pill">Qwen</span>
+        <span class="pill">Mem0</span>
+        <span class="pill">EKS</span>
+        <span class="pill">Graviton</span>
+        <span class="pill">Inferentia/Trainium</span>
+        <span class="pill">S3 Vectors</span>
+      </div>
+    </div>
+    <div class="reveal">
+      <div class="flex-circle">
+        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="grad-blue" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#4A9EE7;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#2563EB;stop-opacity:0.9"/>
+            </linearGradient>
+            <linearGradient id="grad-orange" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#FF9900;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#E07000;stop-opacity:0.9"/>
+            </linearGradient>
+            <linearGradient id="grad-purple" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#A78BFA;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#7C3AED;stop-opacity:0.9"/>
+            </linearGradient>
+          </defs>
+          <path d="M 200,200 L 200,40 A 160,160 0 0,1 338.56,280 Z" fill="url(#grad-blue)"/>
+          <path d="M 200,200 L 338.56,280 A 160,160 0 0,1 61.44,280 Z" fill="url(#grad-purple)"/>
+          <path d="M 200,200 L 61.44,280 A 160,160 0 0,1 200,40 Z" fill="url(#grad-orange)"/>
+          <circle cx="200" cy="200" r="80" fill="#FFC857"/>
+          <text x="200" y="192" text-anchor="middle" fill="#0D1117" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">AWS AI</text>
+          <text x="200" y="212" text-anchor="middle" fill="#0D1117" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">Infrastructure</text>
+          <text x="200" y="100" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">AWS Services</text>
+          <text x="290" y="240" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">Open-source</text>
+          <text x="290" y="256" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">Frameworks</text>
+          <text x="290" y="272" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">&amp; Models</text>
+          <text x="110" y="248" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="12" font-weight="700">Deployment</text>
+          <text x="110" y="264" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="12" font-weight="700">Options</text>
+        </svg>
+      </div>
+      <div class="flex-tagline">
+        <div class="flex-tagline-main">Run Any Model, <span>Anywhere</span></div>
+        <div class="flex-tagline-sub">with flexibility, sovereignty, and granular control</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 2. VALUE PROPOSITION -->
+<section id="value">
+  <div class="reveal">
+    <div class="section-label">VALUE PROPOSITION</div>
+  </div>
+  <div class="value-grid">
+    <div class="value-card reveal">
+      <div class="value-icon">🎛️</div>
+      <h3>Customization & Flexibility</h3>
+      <p>Every layer of the AI stack is composable. Mix open-source and proprietary models, mix-and-match frameworks, and keep full visibility and control over weights, data flows, and infrastructure. When a new model lands, add a route — innovation cycles stop being blocked on platform rework.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🛡️</div>
+      <h3>Sovereignty & Compliance</h3>
+      <p>Meet data residency and compliance requirements without sacrificing access to modern AI. Sensitive data does not leave the customer boundary, and GPUs are not shared with other tenants.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">💰</div>
+      <h3>Cost Efficiency</h3>
+      <p>Compose the right compute per workload — GPU, Trainium, Inferentia, Graviton — and realize up to 40-60% savings versus comparable EC2 instances. Move freely between token-based pricing and GPU-as-a-service so infrastructure spend tracks business value, not abstractions.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🔍</div>
+      <h3>E2E Observability</h3>
+      <p>One pane of glass across infrastructure, models, agent behavior, and cost. From GPU utilization and system performance, through per-prompt response quality, to fine-grained cost attribution by model, team, or project — every operational signal is available at the code level.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🚀</div>
+      <h3>Faster Time-to-Value</h3>
+      <p>Pre-validated reference architectures and adoption guidance compress the PoC-to-production journey from months to weeks. Don't redesign from scratch — start building on top of AWS and a proven OSS ecosystem.</p>
+    </div>
+  </div>
+</section>
+
+<!-- 3. FIVE DIMENSIONS OF FLEXIBILITY -->
+<section id="flexibility">
+  <div class="reveal">
+    <div class="section-label">FLEXIBLE FROM ALL ANGLES</div>
+    <h2 class="section-title">Five Dimensions of Flexibility</h2>
+    <p class="section-desc">Flex AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, switch on the relevant axis instead of redesigning the whole architecture.</p>
+  </div>
+  <div class="flex-grid">
+    <div class="flex-card reveal">
+      <div class="flex-icon">🖥️</div>
+      <h4>Heterogeneous Compute Choice</h4>
+      <div class="flex-en">Mix GPU · Trainium · Inferentia · Graviton</div>
+      <div class="flex-key">Which silicon do you run on?</div>
+      <p>Pick the optimal compute per workload across GPU, AWS Inferentia/Trainium, and Graviton. No lock-in to a single chip family or instance type.</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🔧</div>
+      <h4>Self-Hosted Control</h4>
+      <div class="flex-en">Run open frameworks under your control</div>
+      <div class="flex-key">How do you deploy?</div>
+      <p>Operate open-source frameworks directly to keep full visibility and authority over model weights, data flows, and infrastructure layout.</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">💰</div>
+      <h4>Flexible Consumption Models</h4>
+      <div class="flex-en">Token-based or per-hour GPU</div>
+      <div class="flex-key">How do you pay for it?</div>
+      <p>Move between token-based pricing and per-hour GPU pricing as the workload demands. Tie infrastructure cost directly to business value.</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🌐</div>
+      <h4>Hybrid Deployment Agility</h4>
+      <div class="flex-en">On-prem · EC2 · Bedrock · External</div>
+      <div class="flex-key">Where do you deploy?</div>
+      <p>Move workloads between on-premises, EC2 self-hosted, Amazon Bedrock, and external LLM providers without re-architecting.</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🗺️</div>
+      <h4>Integrated Full-Stack Guidance</h4>
+      <div class="flex-en">From model to platform to agents</div>
+      <div class="flex-key">Where do you start?</div>
+      <p>Reference patterns covering model optimization, storage, platform engineering, and agentic applications. Adopt incrementally — pick the layer that matches your current state and grow from there.</p>
+    </div>
+  </div>
+</section>
+
+<!-- 4. FUNCTIONAL VIEW & BUILDING BLOCKS -->
+<section id="functional">
+  <div class="reveal">
+    <div class="section-label">FUNCTIONAL VIEW & BUILDING BLOCKS</div>
+    <h2 class="section-title">Functional View & Building Blocks</h2>
+    <p class="section-desc">From the application layer down to cloud, on-premises, and edge infrastructure — Flex AI spans every layer. Adopt the components you need today and grow into the rest, or stand up the integrated platform in one pass.</p>
+  </div>
+  <div class="image-placeholder reveal">
+    <div class="image-placeholder-icon">🖼️</div>
+    <div class="image-placeholder-text">[ Diagram placeholder ]</div>
+    <div class="image-placeholder-text" style="font-size: 12px; opacity: 0.6;">A reference architecture image will live here</div>
+  </div>
+</section>
+
+<!-- 5. KEY BENEFITS -->
+<section id="benefits">
+  <div class="reveal">
+    <div class="section-label">KEY BENEFITS</div>
+    <h2 class="section-title">Benefits</h2>
+  </div>
+  <div class="benefits-grid">
+    <div class="benefit-card b1 reveal">
+      <div class="benefit-icon">🚀</div>
+      <h3>Run Any Model Anywhere</h3>
+      <ul>
+        <li>Unified access control</li>
+        <li>No vendor lock-in</li>
+        <li>Data residency and regulatory compliance</li>
+        <li>Self-hosted models, AWS-managed services (Bedrock), and external LLMs — all reachable</li>
+        <li>Self-service portal</li>
+      </ul>
+    </div>
+    <div class="benefit-card b2 reveal">
+      <div class="benefit-icon">💵</div>
+      <h3>Optimize Costs</h3>
+      <ul>
+        <li>Optimize model and GPU utilization</li>
+        <li>Apply and orchestrate heterogeneous compute (GPU / Trainium / Graviton) per workload</li>
+        <li>Smooth migration path from Amazon Bedrock to self-hosted</li>
+      </ul>
+    </div>
+    <div class="benefit-card b3 reveal">
+      <div class="benefit-icon">🛡️</div>
+      <h3>Protect Existing AI Investment</h3>
+      <ul>
+        <li>Bolt-on to existing on-prem environments</li>
+        <li>Hybrid deployment without re-architecting</li>
+        <li>Unified management across on-prem and cloud GPUs</li>
+      </ul>
+    </div>
+    <div class="benefit-card b4 reveal">
+      <div class="benefit-icon">🤖</div>
+      <h3>Agentic AI & Compute Modernization</h3>
+      <ul>
+        <li>One environment for autonomous agent operations</li>
+        <li>End-to-end observability across infrastructure, agent behavior, and outputs</li>
+        <li>Full code-level control over workflows</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- 6. KEY USE CASES -->
+<section id="usecases">
+  <div class="reveal">
+    <div class="section-label">KEY USE CASES</div>
+    <h2 class="section-title">Key Use Cases</h2>
+    <p class="section-desc">GPU-backed model serving, AI Gateway, and Observability are shared building blocks. Compose them with use-case-specific components to fit a wide range of scenarios.</p>
+  </div>
+  <div class="usecase-grid">
+    <div class="usecase-card reveal">
+      <div class="usecase-num">01</div>
+      <h3>Self-hosted Model Serving on AWS</h3>
+      <p>Stand up self-hosted model serving on EKS with AI Gateway (LiteLLM, Kong), inference engines (Ray, SGLang, vLLM), observability (Langfuse, MLflow), and vector DB. Native HuggingFace integration keeps you close to the latest models — with data sovereignty and enhanced observability spanning system metrics through to AI-level signals.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">02</div>
+      <h3>Hybrid Model Serving</h3>
+      <p>Run self-hosted, AWS-managed (Bedrock, Nova, SageMaker), and external (OpenAI, Gemini, Anthropic) models on a single platform. The AI gateway performs workload-optimized routing — switch models per workload without code changes — and centralized policy management keeps governance consistent across providers.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">03</div>
+      <h3>Agentic AI</h3>
+      <p>Start with AWS-native runtimes (Bedrock, Strands, AgentCore), then extend into self-hosted on EKS. Combine custom agent workflows (LangGraph, MCP/A2A) with domain-specific SLMs, and apply heterogeneous compute allocation — Graviton for planning, GPU for reasoning, Trainium/Inferentia for inference — to optimize cost.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">04</div>
+      <h3>Hybrid Cluster</h3>
+      <p>Connect AWS Cloud and on-premises into a single cluster via EKS Hybrid Node. Regulated and sensitive workloads stay on-prem; the rest runs on AWS, with automatic fallback during incidents. "Train on-prem, serve globally on AWS" works without re-architecting.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">05</div>
+      <h3>Cost Optimization with Trainium / Inferentia</h3>
+      <p>AWS purpose-built AI silicon delivers up to 40-60% cost savings versus comparable EC2 instances and industry-leading OTPS. Native PyTorch support and the Neuron Kernel Interface enable fine-grained tuning; Neuron Explorer traces execution flow.</p>
+    </div>
+  </div>
+</section>
+
+<!-- 7. OFFERINGS -->
+<section id="offerings">
+  <div class="reveal">
+    <div class="section-label">OFFERINGS</div>
+    <h2 class="section-title">Offerings</h2>
+    <p class="section-desc">Whether you are building from scratch or hardening an existing environment, Flex AI offers an architecture, support model, and starter kit for every stage.</p>
+  </div>
+  <div class="offering-grid">
+    <div class="offering-card reveal">
+      <div class="offering-icon">🏗️</div>
+      <h3>Baseline for Building Full-stack AI Platform</h3>
+      <ul>
+        <li>Pre-validated reference architectures combining GPUs, OSS frameworks, and AWS services</li>
+        <li>Flexible, scalable design patterns covering many use cases and deployment options</li>
+        <li>Self-service portal for unified model and agent access</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🤝</div>
+      <h3>White-glove Support</h3>
+      <ul>
+        <li>AWS specialist guidance across compute, Kubernetes, storage, and more</li>
+        <li>Best practices to maximize GPU value in production</li>
+        <li>Deployment support across AWS, on-premises, and edge</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🛍️</div>
+      <h3>Open-source via AWS Marketplace</h3>
+      <ul>
+        <li>OSS stacks pre-configured and optimized by experts</li>
+        <li>1-click launch AMIs — skip the integration code</li>
+        <li>Enterprise Edition with hardened security and governance, or BYOL options</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🚀</div>
+      <h3>Production-ready Starter Kit</h3>
+      <ul>
+        <li>GenAI infrastructure toolkit that accelerates enterprise AI deployment</li>
+        <li>AI Gateway, LLM serving, vector DB, embedding models, and E2E observability included</li>
+        <li>Production-ready out of the box</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- 8. CUSTOMER STORIES - PLACEHOLDER -->
+<section id="customers">
+  <div class="reveal">
+    <div class="section-label">CUSTOMER STORIES</div>
+    <h2 class="section-title">Customer Stories</h2>
+    <p class="section-desc">Stories from customers redefining their AI infrastructure strategy with the Flex AI approach are coming soon.</p>
+  </div>
+  <div class="customers-placeholder reveal">
+    <div class="image-placeholder-icon">📋</div>
+    <div class="image-placeholder-text">[ Customer Stories — coming soon ]</div>
+  </div>
+</section>
+
+<!-- 9. CONTACT -->
+<section id="contact">
+  <div class="contact-layout">
+    <div class="contact-info reveal">
+      <div class="section-label">GET IN TOUCH</div>
+      <h2>Contact us</h2>
+      <p>If you are interested in Flex AI, reach out via the channels below or work with your AWS account team (SA / TAM).</p>
+      <div class="contact-emails">
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">🐙</span>
+          <div class="contact-email-text">GitHub Issues</div>
+        </a>
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">💬</span>
+          <div class="contact-email-text">GitHub Discussions</div>
+        </a>
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">⭐</span>
+          <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
+        </a>
+      </div>
+    </div>
+    <div class="contact-form-wrapper reveal">
+      <div class="form-title">Inquiry form</div>
+      <div class="form-group">
+        <label>Name *</label>
+        <input type="text" placeholder="Jane Doe">
+      </div>
+      <div class="form-group">
+        <label>Company / Role *</label>
+        <input type="text" placeholder="Company, role">
+      </div>
+      <div class="form-group">
+        <label>Email *</label>
+        <input type="email" placeholder="example@company.com">
+      </div>
+      <div class="form-group">
+        <label>Message</label>
+        <textarea placeholder="Tell us about your current environment, goals, and timeline."></textarea>
+      </div>
+      <button class="form-submit" onclick="window.open('https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues/new', '_blank')">Open a GitHub issue →</button>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="footer-logo">© 2026 Amazon Web Services, Inc.</div>
+  <div>Architecting Flexible AI Platform on AWS</div>
+  <div>Run Any Model, Anywhere.</div>
+</footer>
+
+<script>
+  const reveals = document.querySelectorAll('.reveal');
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry, i) => {
+      if (entry.isIntersecting) {
+        setTimeout(() => entry.target.classList.add('visible'), i * 50);
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+  reveals.forEach(el => observer.observe(el));
+</script>
+</body>
+</html>

--- a/docs/flex-ai/landing.en.html
+++ b/docs/flex-ai/landing.en.html
@@ -789,45 +789,23 @@
 
 <!-- 9. CONTACT -->
 <section id="contact">
-  <div class="contact-layout">
-    <div class="contact-info reveal">
-      <div class="section-label">GET IN TOUCH</div>
-      <h2>Contact us</h2>
-      <p>If you are interested in Flexible AI, reach out via the channels below or work with your AWS account team (SA / TAM).</p>
-      <div class="contact-emails">
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">🐙</span>
-          <div class="contact-email-text">GitHub Issues</div>
-        </a>
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">💬</span>
-          <div class="contact-email-text">GitHub Discussions</div>
-        </a>
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">⭐</span>
-          <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
-        </a>
-      </div>
-    </div>
-    <div class="contact-form-wrapper reveal">
-      <div class="form-title">Inquiry form</div>
-      <div class="form-group">
-        <label>Name *</label>
-        <input type="text" placeholder="Jane Doe">
-      </div>
-      <div class="form-group">
-        <label>Company / Role *</label>
-        <input type="text" placeholder="Company, role">
-      </div>
-      <div class="form-group">
-        <label>Email *</label>
-        <input type="email" placeholder="example@company.com">
-      </div>
-      <div class="form-group">
-        <label>Message</label>
-        <textarea placeholder="Tell us about your current environment, goals, and timeline."></textarea>
-      </div>
-      <button class="form-submit" onclick="window.open('https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues/new', '_blank')">Open a GitHub issue →</button>
+  <div class="contact-info reveal" style="max-width: 820px; margin: 0 auto; text-align: center;">
+    <div class="section-label">GET IN TOUCH</div>
+    <h2>Contact us</h2>
+    <p style="margin-left: auto; margin-right: auto;">If you are interested in Flexible AI, reach out via the GitHub channels below, or work with your AWS account team (SA / TAM).</p>
+    <div class="contact-emails" style="max-width: 520px; margin: 0 auto;">
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions/categories/q-a" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">💬</span>
+        <div class="contact-email-text">GitHub Discussions · Q&amp;A</div>
+      </a>
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">🐙</span>
+        <div class="contact-email-text">GitHub Issues</div>
+      </a>
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">⭐</span>
+        <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
+      </a>
     </div>
   </div>
 </section>

--- a/docs/flex-ai/landing.html
+++ b/docs/flex-ai/landing.html
@@ -779,7 +779,7 @@
   <div class="reveal">
     <div class="section-label">CUSTOMER STORIES</div>
     <h2 class="section-title">고객 사례</h2>
-    <p class="section-desc">FlexAI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.</p>
+    <p class="section-desc">Flexible AI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.</p>
   </div>
   <div class="customers-placeholder reveal">
     <div class="image-placeholder-icon">📋</div>

--- a/docs/flex-ai/landing.html
+++ b/docs/flex-ai/landing.html
@@ -1,0 +1,854 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Architecting Flexible AI Platform on AWS</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;500;700;900&family=DM+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --aws-orange: #FF9900;
+    --aws-orange-light: #FFB84D;
+    --aws-dark: #0D1117;
+    --aws-navy: #0F1B2D;
+    --aws-mid: #1A2B45;
+    --aws-border: rgba(255,153,0,0.2);
+    --aws-border-soft: rgba(255,255,255,0.08);
+    --aws-text: #E8EFF7;
+    --aws-muted: #8BA3BE;
+    --accent-blue: #4A9EE7;
+    --accent-purple: #A78BFA;
+    --accent-green: #34D399;
+    --font-display: 'DM Mono', monospace;
+    --font-body: 'Noto Sans KR', sans-serif;
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html { scroll-behavior: smooth; }
+  body {
+    font-family: var(--font-body);
+    background: var(--aws-dark);
+    color: var(--aws-text);
+    line-height: 1.7;
+    overflow-x: hidden;
+  }
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    background: rgba(13,17,23,0.92);
+    backdrop-filter: blur(12px);
+    border-bottom: 1px solid var(--aws-border);
+    padding: 0 5%;
+    display: flex; align-items: center; justify-content: space-between;
+    height: 60px;
+  }
+  .nav-logo {
+    display: flex; align-items: center; gap: 10px;
+    font-family: var(--font-display); font-size: 13px; letter-spacing: 0.08em;
+    color: var(--aws-orange); text-decoration: none;
+  }
+  .nav-logo svg { width: 28px; height: 28px; }
+  .nav-links { display: flex; gap: 26px; list-style: none; }
+  .nav-links a {
+    color: var(--aws-muted); text-decoration: none;
+    font-size: 13px; letter-spacing: 0.04em;
+    transition: color 0.2s;
+  }
+  .nav-links a:hover { color: var(--aws-orange); }
+  .nav-cta {
+    background: var(--aws-orange); color: var(--aws-dark) !important;
+    padding: 7px 18px; border-radius: 4px;
+    font-weight: 700 !important; font-size: 13px !important;
+  }
+  .nav-cta:hover { background: var(--aws-orange-light) !important; color: var(--aws-dark) !important; }
+
+  .hero {
+    min-height: 100vh;
+    display: flex; align-items: center;
+    padding: 100px 5% 60px;
+    position: relative; overflow: hidden;
+  }
+  .hero-bg {
+    position: absolute; inset: 0;
+    background:
+      radial-gradient(ellipse 80% 60% at 70% 50%, rgba(255,153,0,0.08) 0%, transparent 60%),
+      radial-gradient(ellipse 60% 80% at 20% 80%, rgba(74,158,231,0.05) 0%, transparent 60%),
+      linear-gradient(160deg, var(--aws-dark) 0%, var(--aws-navy) 100%);
+  }
+  .hero-grid {
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(rgba(255,153,0,0.04) 1px, transparent 1px),
+      linear-gradient(90deg, rgba(255,153,0,0.04) 1px, transparent 1px);
+    background-size: 60px 60px;
+    mask-image: radial-gradient(ellipse 80% 80% at 60% 40%, black 0%, transparent 70%);
+  }
+  .hero-content { position: relative; z-index: 2; max-width: 880px; }
+  .hero h1 {
+    font-size: clamp(38px, 5.5vw, 68px);
+    font-weight: 900; line-height: 1.08;
+    letter-spacing: -0.025em; margin-bottom: 24px;
+    animation: fadeUp 0.6s 0.1s ease both;
+  }
+  .hero h1 .accent { color: var(--aws-orange); }
+  .hero-sub {
+    font-family: var(--font-display);
+    font-size: clamp(18px, 2.5vw, 28px);
+    color: var(--aws-orange);
+    letter-spacing: 0.04em; margin-bottom: 28px;
+    animation: fadeUp 0.6s 0.2s ease both;
+  }
+  .hero p {
+    font-size: 17px; color: var(--aws-muted);
+    max-width: 660px; margin-bottom: 40px;
+    animation: fadeUp 0.6s 0.3s ease both;
+  }
+  .hero-actions {
+    display: flex; gap: 16px; flex-wrap: wrap;
+    animation: fadeUp 0.6s 0.4s ease both;
+  }
+  .btn-primary {
+    background: var(--aws-orange); color: var(--aws-dark);
+    padding: 14px 32px; border-radius: 4px;
+    font-weight: 700; font-size: 15px; text-decoration: none;
+    border: none; cursor: pointer;
+    transition: background 0.2s, transform 0.15s;
+    display: inline-flex; align-items: center; gap: 8px;
+  }
+  .btn-primary:hover { background: var(--aws-orange-light); transform: translateY(-1px); }
+  .btn-outline {
+    background: transparent; color: var(--aws-text);
+    padding: 14px 32px; border-radius: 4px;
+    font-weight: 500; font-size: 15px; text-decoration: none;
+    border: 1px solid rgba(255,255,255,0.2); cursor: pointer;
+    transition: border-color 0.2s, color 0.2s, transform 0.15s;
+    display: inline-flex; align-items: center; gap: 8px;
+  }
+  .btn-outline:hover { border-color: var(--aws-orange); color: var(--aws-orange); transform: translateY(-1px); }
+
+  section { padding: 100px 5%; }
+  .section-label {
+    font-family: var(--font-display);
+    font-size: 11px; letter-spacing: 0.15em;
+    color: var(--aws-orange); text-transform: uppercase;
+    margin-bottom: 12px;
+  }
+  .section-title {
+    font-size: clamp(28px, 3.5vw, 44px);
+    font-weight: 700; letter-spacing: -0.02em;
+    margin-bottom: 16px; line-height: 1.2;
+  }
+  .section-desc {
+    font-size: 16px; color: var(--aws-muted);
+    max-width: 720px; margin-bottom: 60px;
+  }
+
+  /* OVERVIEW */
+  #overview {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .overview-layout { display: grid; grid-template-columns: 1fr 1fr; gap: 80px; align-items: center; }
+  .overview-text p {
+    font-size: 16px; color: var(--aws-muted); line-height: 1.8;
+    margin-bottom: 20px;
+  }
+  .overview-text strong { color: var(--aws-text); }
+  .overview-text .quote-block strong { color: var(--accent-blue); }
+  .tech-pills { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 24px; }
+  .pill {
+    font-family: var(--font-display); font-size: 11px;
+    background: rgba(255,153,0,0.1);
+    border: 1px solid var(--aws-border);
+    color: var(--aws-orange);
+    padding: 6px 12px; border-radius: 20px;
+  }
+  .flex-circle {
+    position: relative; width: 100%;
+    aspect-ratio: 1; max-width: 480px; margin: 0 auto;
+  }
+  .flex-circle svg { width: 100%; height: 100%; }
+  .flex-tagline { text-align: center; margin-top: 24px; }
+  .flex-tagline-main { font-size: 28px; font-weight: 700; margin-bottom: 8px; }
+  .flex-tagline-main span { color: var(--aws-orange); }
+  .flex-tagline-sub { font-size: 14px; color: var(--aws-muted); }
+
+  /* VALUE PROPS */
+  #value { background: var(--aws-dark); }
+  .value-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; }
+  .value-card {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    position: relative; overflow: hidden;
+    transition: border-color 0.3s, transform 0.2s;
+  }
+  .value-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .value-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0;
+    height: 3px; background: var(--aws-orange);
+    transform: scaleX(0); transform-origin: left;
+    transition: transform 0.3s;
+  }
+  .value-card:hover::before { transform: scaleX(1); }
+  .value-icon {
+    width: 52px; height: 52px;
+    background: rgba(255,153,0,0.1);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 26px; margin-bottom: 20px;
+  }
+  .value-card h3 { font-size: 18px; font-weight: 700; margin-bottom: 12px; line-height: 1.3; }
+  .value-card p { font-size: 14px; color: var(--aws-muted); line-height: 1.7; }
+
+  /* FLEXIBILITY (5 dimensions) */
+  #flexibility {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .flex-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; }
+  .flex-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 10px; padding: 24px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .flex-card:hover { border-color: var(--aws-orange); transform: translateY(-3px); }
+  .flex-icon { font-size: 28px; margin-bottom: 14px; }
+  .flex-card h4 {
+    font-size: 15px; font-weight: 700; margin-bottom: 6px;
+    color: var(--aws-text); line-height: 1.3;
+  }
+  .flex-card .flex-en {
+    font-family: var(--font-display); font-size: 11px;
+    color: var(--accent-blue); margin-bottom: 14px;
+  }
+  .flex-card .flex-key {
+    font-size: 13px; color: var(--aws-orange); font-weight: 500;
+    margin-bottom: 12px; font-style: italic;
+  }
+  .flex-card p { font-size: 12px; color: var(--aws-muted); line-height: 1.6; }
+
+  /* FUNCTIONAL VIEW - placeholder */
+  #functional { background: var(--aws-dark); }
+  .image-placeholder {
+    background: var(--aws-navy);
+    border: 2px dashed var(--aws-border);
+    border-radius: 12px;
+    min-height: 480px;
+    display: flex; align-items: center; justify-content: center;
+    flex-direction: column; gap: 12px;
+    color: var(--aws-muted);
+  }
+  .image-placeholder-icon { font-size: 48px; opacity: 0.5; }
+  .image-placeholder-text { font-size: 14px; font-family: var(--font-display); letter-spacing: 0.05em; }
+
+  /* BENEFITS */
+  #benefits {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .benefits-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+  .benefit-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    position: relative; overflow: hidden;
+    transition: border-color 0.3s, transform 0.2s;
+  }
+  .benefit-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .benefit-card::before {
+    content: ''; position: absolute; top: 0; left: 0; right: 0;
+    height: 3px; transform: scaleX(0); transform-origin: left;
+    transition: transform 0.3s;
+  }
+  .benefit-card:hover::before { transform: scaleX(1); }
+  .benefit-card.b1::before { background: var(--accent-purple); }
+  .benefit-card.b2::before { background: var(--accent-green); }
+  .benefit-card.b3::before { background: var(--accent-blue); }
+  .benefit-card.b4::before { background: var(--aws-orange); }
+  .benefit-icon {
+    width: 48px; height: 48px;
+    border-radius: 10px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 24px; margin-bottom: 20px;
+  }
+  .benefit-card.b1 .benefit-icon { background: rgba(167,139,250,0.15); }
+  .benefit-card.b2 .benefit-icon { background: rgba(52,211,153,0.15); }
+  .benefit-card.b3 .benefit-icon { background: rgba(74,158,231,0.15); }
+  .benefit-card.b4 .benefit-icon { background: rgba(255,153,0,0.15); }
+  .benefit-card h3 { font-size: 17px; font-weight: 700; margin-bottom: 16px; line-height: 1.3; }
+  .benefit-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+  .benefit-card li {
+    font-size: 13px; color: var(--aws-muted);
+    padding-left: 16px; position: relative; line-height: 1.6;
+  }
+  .benefit-card li::before {
+    content: '✓'; color: var(--aws-orange);
+    position: absolute; left: 0; font-weight: 700;
+  }
+
+  /* USE CASES */
+  #usecases { background: var(--aws-dark); }
+  .usecase-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 16px; }
+  .usecase-card {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 28px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .usecase-card:hover { border-color: var(--aws-orange); transform: translateY(-3px); }
+  .usecase-num {
+    font-family: var(--font-display);
+    font-size: 28px; color: var(--aws-orange);
+    line-height: 1; margin-bottom: 16px; font-weight: 500;
+  }
+  .usecase-card h3 { font-size: 16px; font-weight: 700; margin-bottom: 12px; line-height: 1.35; }
+  .usecase-card p { font-size: 13px; color: var(--aws-muted); line-height: 1.65; }
+
+  /* OFFERINGS */
+  #offerings {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+    border-bottom: 1px solid var(--aws-border);
+  }
+  .offering-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+  .offering-card {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 12px; padding: 32px;
+    transition: border-color 0.2s, transform 0.2s;
+  }
+  .offering-card:hover { border-color: var(--aws-orange); transform: translateY(-4px); }
+  .offering-icon {
+    width: 56px; height: 56px;
+    border-radius: 12px;
+    display: flex; align-items: center; justify-content: center;
+    font-size: 28px; margin-bottom: 20px;
+    background: linear-gradient(135deg, rgba(255,153,0,0.15), rgba(255,153,0,0.05));
+    border: 1px solid var(--aws-border);
+  }
+  .offering-card h3 {
+    font-size: 17px; font-weight: 700; margin-bottom: 16px;
+    color: var(--aws-orange); line-height: 1.3;
+  }
+  .offering-card ul { list-style: none; display: flex; flex-direction: column; gap: 10px; }
+  .offering-card li {
+    font-size: 13px; color: var(--aws-muted);
+    padding-left: 14px; position: relative; line-height: 1.6;
+  }
+  .offering-card li::before {
+    content: '→'; color: var(--aws-orange);
+    position: absolute; left: 0;
+  }
+
+  /* CUSTOMER STORIES - empty placeholder */
+  #customers { background: var(--aws-dark); }
+  .customers-placeholder {
+    background: var(--aws-navy);
+    border: 2px dashed var(--aws-border);
+    border-radius: 12px;
+    min-height: 240px;
+    display: flex; align-items: center; justify-content: center;
+    flex-direction: column; gap: 12px;
+    color: var(--aws-muted);
+  }
+
+  /* CONTACT */
+  #contact {
+    background: var(--aws-navy);
+    border-top: 1px solid var(--aws-border);
+  }
+  .contact-layout {
+    display: grid; grid-template-columns: 1fr 1.2fr; gap: 80px; align-items: start;
+  }
+  .contact-info h2 { font-size: clamp(28px, 3.5vw, 40px); margin-bottom: 16px; }
+  .contact-info > p { font-size: 16px; color: var(--aws-muted); margin-bottom: 32px; }
+  .contact-emails { display: flex; flex-direction: column; gap: 12px; }
+  .contact-email {
+    display: flex; gap: 14px; align-items: center;
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 8px; padding: 16px 20px;
+    text-decoration: none; color: var(--aws-text);
+    transition: border-color 0.2s;
+  }
+  .contact-email:hover { border-color: var(--aws-orange); }
+  .contact-email-icon { font-size: 20px; }
+  .contact-email-text { font-size: 14px; font-weight: 500; font-family: var(--font-display); }
+
+  .contact-form-wrapper {
+    background: var(--aws-mid);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px; padding: 36px;
+  }
+  .form-title { font-size: 20px; font-weight: 700; margin-bottom: 24px; }
+  .form-group { margin-bottom: 20px; }
+  .form-group label {
+    display: block; font-size: 13px; color: var(--aws-muted);
+    margin-bottom: 8px;
+  }
+  .form-group input,
+  .form-group textarea {
+    width: 100%;
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border-soft);
+    border-radius: 6px; padding: 12px 16px;
+    color: var(--aws-text); font-size: 14px;
+    font-family: var(--font-body);
+    transition: border-color 0.2s; outline: none;
+  }
+  .form-group input:focus,
+  .form-group textarea:focus { border-color: var(--aws-orange); }
+  .form-group textarea { resize: vertical; min-height: 100px; }
+  .form-submit {
+    width: 100%;
+    background: var(--aws-orange); color: var(--aws-dark);
+    padding: 14px; border-radius: 6px;
+    font-weight: 700; font-size: 15px;
+    border: none; cursor: pointer;
+    transition: background 0.2s;
+  }
+  .form-submit:hover { background: var(--aws-orange-light); }
+
+  footer {
+    background: var(--aws-dark);
+    border-top: 1px solid var(--aws-border);
+    padding: 32px 5%;
+    display: flex; align-items: center; justify-content: space-between;
+    font-size: 12px; color: var(--aws-muted); flex-wrap: wrap; gap: 16px;
+  }
+  .footer-logo { font-family: var(--font-display); font-size: 12px; }
+
+  @keyframes fadeUp {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
+  }
+  .reveal {
+    opacity: 0; transform: translateY(24px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+  .reveal.visible { opacity: 1; transform: translateY(0); }
+
+  @media (max-width: 1100px) {
+    .flex-grid { grid-template-columns: repeat(3, 1fr); }
+    .usecase-grid { grid-template-columns: repeat(3, 1fr); }
+    .benefits-grid, .offering-grid, .value-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 900px) {
+    .overview-layout, .contact-layout { grid-template-columns: 1fr; gap: 40px; }
+    nav .nav-links { display: none; }
+  }
+  @media (max-width: 600px) {
+    .flex-grid, .usecase-grid, .benefits-grid, .offering-grid, .value-grid { grid-template-columns: 1fr; }
+    section { padding: 60px 5%; }
+  }
+</style>
+</head>
+<body>
+
+<nav>
+  <a href="#" class="nav-logo">
+    <svg viewBox="0 0 40 40" fill="none">
+      <rect width="40" height="40" rx="6" fill="#FF9900" opacity="0.15"/>
+      <path d="M8 28C12 24 16 20 20 20C24 20 28 24 32 28" stroke="#FF9900" stroke-width="2" stroke-linecap="round"/>
+      <path d="M8 20C12 16 16 14 20 14C24 14 28 16 32 20" stroke="#FF9900" stroke-width="2" stroke-linecap="round" opacity="0.6"/>
+      <path d="M8 12C12 10 16 9 20 9C24 9 28 10 32 12" stroke="#FF9900" stroke-width="2" stroke-linecap="round" opacity="0.3"/>
+    </svg>
+    FLEXIBLE AI · AWS
+  </a>
+  <ul class="nav-links">
+    <li><a href="#overview">Overview</a></li>
+    <li><a href="#value">Value Proposition</a></li>
+    <li><a href="#flexibility">Flexibility</a></li>
+    <li><a href="#functional">Functional View</a></li>
+    <li><a href="#benefits">Benefits</a></li>
+    <li><a href="#usecases">Use Cases</a></li>
+    <li><a href="#offerings">Offerings</a></li>
+    <li><a href="#customers">Customers</a></li>
+    <li><a href="landing.en.html" title="English">EN</a></li>
+    <li><a href="../" title="Back to docs site">Docs</a></li>
+    <li><a href="#contact" class="nav-cta">문의</a></li>
+  </ul>
+</nav>
+
+<section class="hero">
+  <div class="hero-bg"></div>
+  <div class="hero-grid"></div>
+  <div class="hero-content">
+    <h1>Architecting Flexible<br><span class="accent">AI Platform</span> on AWS</h1>
+    <div class="hero-sub">Run Any Model, Anywhere.</div>
+    <p>유연성(Flexibility), 주권(Sovereignty), 그리고 세밀한 제어(Granular Control)를 갖춘 차세대 AI 플랫폼. 어떤 모델이든, 어떤 환경에서든, 비즈니스 요구에 맞춰 자유롭게 구축하고 운영하세요.</p>
+    <div class="hero-actions">
+      <a href="#overview" class="btn-primary">솔루션 알아보기 →</a>
+      <a href="#contact" class="btn-outline">문의하기</a>
+    </div>
+  </div>
+</section>
+
+<!-- 1. OVERVIEW -->
+<section id="overview">
+  <div class="overview-layout">
+    <div class="overview-text reveal">
+      <div class="section-label">OVERVIEW</div>
+      <p class="quote-block">AI를 프로덕션에서 운영하는 기업들은 공통된 과제에 직면합니다. <strong>"새로운 모델이 매주 쏟아지는데, 기존 파이프라인에 적용하려면 매번 재작업이 필요하다"</strong>, <strong>"사업부·팀마다 GPU를 따로 쓰고 모델을 개별 배포하다 보니, 전사 차원의 비용 가시성과 통합 관리가 불가능하다"</strong>, <strong>"API 기반 모델 호출 비용이 통제 불가능한 속도로 증가하고 있다"</strong>, <strong>"클라우드로 확장하고 싶지만, 그동안 투자해 온 온프레미스 GPU 자산도 함께 활용해야 한다"</strong> — Flexible AI Platform on AWS는 이러한 프로덕션 환경의 현실적 과제를 정면으로 해결하기 위해 설계된 통합 AI 플랫폼 솔루션입니다.</p>
+      <p>AWS의 <strong>핵심 인프라 서비스</strong>(Graviton, GPU/Trainium/Inferentia, EKS, S3 Vectors 등)와 <strong>검증된 오픈소스 기술</strong>(LangGraph, Mem0, LiteLLM, Langfuse, vLLM, Qwen 등)을 유기적으로 결합하여, 고객이 원하는 모델과 프레임워크를 자유롭게 선택하고, 데이터 파이프라인부터 모델 학습·서빙, 에이전틱 애플리케이션까지 아우르는 풀스택 AI 플랫폼을 단일 환경에서 일관되게 구축·운영할 수 있도록 사전 검증된 레퍼런스 아키텍처와 도입 가이던스를 제공합니다.</p>
+      <div class="tech-pills">
+        <span class="pill">LangGraph</span>
+        <span class="pill">LiteLLM</span>
+        <span class="pill">vLLM</span>
+        <span class="pill">Langfuse</span>
+        <span class="pill">Qwen</span>
+        <span class="pill">Mem0</span>
+        <span class="pill">EKS</span>
+        <span class="pill">Graviton</span>
+        <span class="pill">Inferentia/Trainium</span>
+        <span class="pill">S3 Vectors</span>
+      </div>
+    </div>
+    <div class="reveal">
+      <div class="flex-circle">
+        <svg viewBox="0 0 400 400" xmlns="http://www.w3.org/2000/svg">
+          <defs>
+            <linearGradient id="grad-blue" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#4A9EE7;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#2563EB;stop-opacity:0.9"/>
+            </linearGradient>
+            <linearGradient id="grad-orange" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#FF9900;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#E07000;stop-opacity:0.9"/>
+            </linearGradient>
+            <linearGradient id="grad-purple" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" style="stop-color:#A78BFA;stop-opacity:0.9"/>
+              <stop offset="100%" style="stop-color:#7C3AED;stop-opacity:0.9"/>
+            </linearGradient>
+          </defs>
+          <path d="M 200,200 L 200,40 A 160,160 0 0,1 338.56,280 Z" fill="url(#grad-blue)"/>
+          <path d="M 200,200 L 338.56,280 A 160,160 0 0,1 61.44,280 Z" fill="url(#grad-purple)"/>
+          <path d="M 200,200 L 61.44,280 A 160,160 0 0,1 200,40 Z" fill="url(#grad-orange)"/>
+          <circle cx="200" cy="200" r="80" fill="#FFC857"/>
+          <text x="200" y="192" text-anchor="middle" fill="#0D1117" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">AWS AI</text>
+          <text x="200" y="212" text-anchor="middle" fill="#0D1117" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">Infrastructure</text>
+          <text x="200" y="100" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="13" font-weight="700">AWS Services</text>
+          <text x="290" y="240" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">Open-source</text>
+          <text x="290" y="256" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">Frameworks</text>
+          <text x="290" y="272" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="11" font-weight="700">&amp; Models</text>
+          <text x="110" y="248" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="12" font-weight="700">Deployment</text>
+          <text x="110" y="264" text-anchor="middle" fill="#FFFFFF" font-family="Noto Sans KR, sans-serif" font-size="12" font-weight="700">Options</text>
+        </svg>
+      </div>
+      <div class="flex-tagline">
+        <div class="flex-tagline-main">Run Any Model, <span>Anywhere</span></div>
+        <div class="flex-tagline-sub">with flexibility, sovereignty, and granular control</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- 2. VALUE PROPOSITION -->
+<section id="value">
+  <div class="reveal">
+    <div class="section-label">VALUE PROPOSITION</div>
+  </div>
+  <div class="value-grid">
+    <div class="value-card reveal">
+      <div class="value-icon">🎛️</div>
+      <h3>Customization & Flexibility</h3>
+      <p>AI 스택의 모든 레이어를 비즈니스 요구에 맞춰 자유롭게 선택하고 제어할 수 있습니다. 오픈소스와 프로프라이어터리 모델을 자유롭게 조합하고, 선호하는 프레임워크를 mix and match하며, 모델 가중치부터 데이터 흐름, 인프라 구성까지 완전한 가시성과 제어권을 확보하세요. 신규 모델이 출시되면 라우팅 추가만으로 즉시 도입할 수 있어 AI 혁신 사이클이 가속됩니다.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🛡️</div>
+      <h3>Sovereignty & Compliance</h3>
+      <p>데이터 레지던시 및 컴플라이언스를 충족합니다. 민감 정보가 외부로 노출되거나 타 고객 GPU 리소스와 공유될 우려 없이, 데이터 주권을 유지하면서 최신 AI 기술을 도입할 수 있습니다.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">💰</div>
+      <h3>Cost Efficiency</h3>
+      <p>워크로드별로 최적의 컴퓨트 — GPU, Trainium, Inferentia, Graviton — 를 자유롭게 조합하여 동급 EC2 대비 최대 40-60% 비용을 절감합니다. 토큰 기반 가격과 GPUaaS 모델 사이를 유연하게 전환하여 인프라 지출을 실제 비즈니스 가치에 직접 연동할 수 있습니다.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🔍</div>
+      <h3>E2E Observability</h3>
+      <p>인프라, 모델, 에이전트 동작, 비용까지 — AI 워크로드의 모든 계층을 단일 화면에서 모니터링합니다. GPU 활용률과 시스템 성능부터 프롬프트별 응답 품질, 모델·팀·프로젝트 단위 세분화된 비용 추적까지, 운영에 필요한 모든 신호를 코드 레벨로 확보합니다.</p>
+    </div>
+    <div class="value-card reveal">
+      <div class="value-icon">🚀</div>
+      <h3>Faster Time-to-Value</h3>
+      <p>사전 검증된 레퍼런스 아키텍처와 도입 가이던스를 통해 PoC에서 프로덕션까지의 여정을 수개월에서 수주로 단축합니다. 처음부터 다시 설계할 필요 없이, AWS와 검증된 오픈소스 생태계 위에서 즉시 구축을 시작할 수 있습니다.</p>
+    </div>
+  </div>
+</section>
+
+<!-- 3. FIVE DIMENSIONS OF FLEXIBILITY -->
+<section id="flexibility">
+  <div class="reveal">
+    <div class="section-label">FLEXIBLE FROM ALL ANGLES</div>
+    <h2 class="section-title">5가지 차원의 유연성</h2>
+    <p class="section-desc">AI 인프라의 모든 측면에서 유연성을 제공합니다. 비용·성능·거버넌스 요구가 변화할 때 전체 아키텍처를 다시 설계할 필요 없이, 각 차원에서 자유롭게 전환할 수 있습니다.</p>
+  </div>
+  <div class="flex-grid">
+    <div class="flex-card reveal">
+      <div class="flex-icon">🖥️</div>
+      <h4>이기종 컴퓨트 선택</h4>
+      <div class="flex-en">Heterogeneous Compute Choice</div>
+      <div class="flex-key">어떤 실리콘을 사용할 것인가?</div>
+      <p>GPU, AWS Inferentia/Trainium, Graviton 중 워크로드 특성에 맞는 최적의 컴퓨팅을 자유롭게 선택. 단일 칩이나 인스턴스 유형에 종속되지 않음</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🔧</div>
+      <h4>Self-Hosted 완전 제어</h4>
+      <div class="flex-en">Self-Hosted Control</div>
+      <div class="flex-key">어떻게 배포할 것인가?</div>
+      <p>오픈소스 프레임워크를 직접 배포·운영하여 모델 가중치, 데이터 흐름, 인프라 구성에 대한 완전한 가시성과 통제권 확보</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">💰</div>
+      <h4>유연한 소비 모델</h4>
+      <div class="flex-en">Flexible Consumption Models</div>
+      <div class="flex-key">어떻게 비용을 지불할 것인가?</div>
+      <p>토큰 기반 과금과 시간당 GPU 과금 사이를 자유롭게 전환. 인프라 비용을 비즈니스 가치와 직접 연동</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🌐</div>
+      <h4>하이브리드 배포 민첩성</h4>
+      <div class="flex-en">Hybrid Deployment Agility</div>
+      <div class="flex-key">어디에 배포할 것인가?</div>
+      <p>온프레미스, EC2 기반 Self-hosted, Amazon Bedrock, 외부 LLM을 재설계 없이 유동적으로 이동</p>
+    </div>
+    <div class="flex-card reveal">
+      <div class="flex-icon">🗺️</div>
+      <h4>통합 풀스택 가이던스</h4>
+      <div class="flex-en">Integrated Full-Stack Guidance</div>
+      <div class="flex-key">어디서부터 시작할 것인가?</div>
+      <p>모델 최적화부터 스토리지, 플랫폼 엔지니어링, 에이전틱 애플리케이션까지 전체를 아우르는 통합 아키텍처 패턴 제공으로, 고객의 현황과 비즈니스 요구사항에 맞게 점진적 도입 가능</p>
+    </div>
+  </div>
+</section>
+
+<!-- 4. FUNCTIONAL VIEW & BUILDING BLOCKS -->
+<section id="functional">
+  <div class="reveal">
+    <div class="section-label">FUNCTIONAL VIEW & BUILDING BLOCKS</div>
+    <h2 class="section-title">기능 구성 & 빌딩 블록</h2>
+    <p class="section-desc">Application 레이어부터 Cloud·On-prem·Edge 인프라까지 전 계층을 포괄하는 구조. 환경에 맞춰 필요한 컴포넌트부터 점진적으로 확장하거나, 통합 플랫폼으로 한 번에 구축할 수 있습니다.</p>
+  </div>
+  <div class="image-placeholder reveal">
+    <div class="image-placeholder-icon">🖼️</div>
+    <div class="image-placeholder-text">[ 다이어그램 이미지 영역 ]</div>
+    <div class="image-placeholder-text" style="font-size: 12px; opacity: 0.6;">이미지 파일을 첨부하면 이 자리에 들어갑니다</div>
+  </div>
+</section>
+
+<!-- 5. KEY BENEFITS -->
+<section id="benefits">
+  <div class="reveal">
+    <div class="section-label">KEY BENEFITS</div>
+    <h2 class="section-title">Benefits</h2>
+  </div>
+  <div class="benefits-grid">
+    <div class="benefit-card b1 reveal">
+      <div class="benefit-icon">🚀</div>
+      <h3>Run Any Model Anywhere</h3>
+      <ul>
+        <li>통합 액세스 제어 (Unified access control)</li>
+        <li>벤더 락인 제거</li>
+        <li>데이터 레지던시 및 규제 준수</li>
+        <li>Self-hosted 모델, Amazon 관리형 서비스(Bedrock), 외부 LLM 호출까지 유연하게 이용</li>
+        <li>Self-service portal</li>
+      </ul>
+    </div>
+    <div class="benefit-card b2 reveal">
+      <div class="benefit-icon">💵</div>
+      <h3>Optimize Costs</h3>
+      <ul>
+        <li>모델 및 GPU 활용 최적화</li>
+        <li>이기종 컴퓨팅(GPU/Trainium/Graviton)을 워크로드별로 적용·오케스트레이션</li>
+        <li>Amazon Bedrock에서 Self-hosted로의 매끄러운 마이그레이션 지원</li>
+      </ul>
+    </div>
+    <div class="benefit-card b3 reveal">
+      <div class="benefit-icon">🛡️</div>
+      <h3>Protect Existing AI Investment</h3>
+      <ul>
+        <li>온프레미스 환경에 Bolt-on 방식으로 적용 가능</li>
+        <li>재설계(Re-architecting) 없이 하이브리드 배포</li>
+        <li>온프레미스·클라우드 GPU 통합 관리</li>
+      </ul>
+    </div>
+    <div class="benefit-card b4 reveal">
+      <div class="benefit-icon">🤖</div>
+      <h3>Agentic AI & Compute Modernization</h3>
+      <ul>
+        <li>자율 에이전트 운영을 위한 통합 환경</li>
+        <li>인프라·에이전트 행동·아웃풋에 대한 E2E Observability</li>
+        <li>워크플로우 코드 레벨 완전 제어</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- 6. KEY USE CASES -->
+<section id="usecases">
+  <div class="reveal">
+    <div class="section-label">KEY USE CASES</div>
+    <h2 class="section-title">Key Use Cases</h2>
+    <p class="section-desc">GPU 기반 모델 서빙, AI Gateway, Observability 등 공통 컴포넌트 위에 use case별 컴포넌트를 조합하여 다양한 시나리오를 구현할 수 있습니다.</p>
+  </div>
+  <div class="usecase-grid">
+    <div class="usecase-card reveal">
+      <div class="usecase-num">01</div>
+      <h3>Self-hosted Model Serving on AWS</h3>
+      <p>EKS 위에 self-hosted 모델 서빙 환경을 구축하고 AI Gateway(LiteLLM·Kong), Inference Engines(Ray·SGLang·vLLM), Observability(Langfuse·mlflow), Vector DB를 통합. HuggingFace 네이티브 연동으로 신규 모델에 빠르게 접근하며, 데이터 주권과 시스템부터 AI 레벨까지의 Enhanced Observability를 확보합니다.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">02</div>
+      <h3>Hybrid Model Serving</h3>
+      <p>Self-hosted, AWS-managed(Bedrock·Nova·SageMaker), 외부 모델(OpenAI·Gemini·Anthropic)을 단일 플랫폼에서 통합 운영. AI Gateway가 workload-optimized routing을 수행해 워크로드별 최적 모델로 코드 변경 없이 라우팅하고, centralized policy management로 거버넌스를 유지합니다.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">03</div>
+      <h3>Agentic AI</h3>
+      <p>AWS Native(Bedrock·Strands·AgentCore)로 시작해 EKS 기반 Self-hosted로 확장. Custom Agent workflow(LangGraph·MCP/A2A)와 도메인 특화 SLM을 자유롭게 결합하며, Heterogeneous Compute Allocation(Graviton for planning, GPU for reasoning, Trn/Inf for inference)으로 비용을 최적화합니다.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">04</div>
+      <h3>Hybrid Cluster</h3>
+      <p>AWS Cloud와 On-prem을 EKS Hybrid Node로 연결하는 단일 클러스터. 규제·민감 워크로드는 온프레미스, 나머지는 AWS에서 처리하며, 장애 시 AWS로 자동 fallback. 온프렘 학습 + AWS 글로벌 추론 시나리오도 재설계 없이 구현됩니다.</p>
+    </div>
+    <div class="usecase-card reveal">
+      <div class="usecase-num">05</div>
+      <h3>Cost Optimization with Trainium/Inferentia</h3>
+      <p>AWS 자체 AI 칩으로 동급 EC2 대비 최대 40-60% 비용 절감과 업계 최고 수준의 OTPS 달성. PyTorch 네이티브 지원과 Neuron Kernel Interface를 통한 fine-grained 튜닝, Neuron Explorer를 통한 실행 흐름 추적을 제공합니다.</p>
+    </div>
+  </div>
+</section>
+
+<!-- 7. OFFERINGS -->
+<section id="offerings">
+  <div class="reveal">
+    <div class="section-label">OFFERINGS</div>
+    <h2 class="section-title">Offerings</h2>
+    <p class="section-desc">아키텍처를 처음부터 구축하는 환경부터 이미 갖추고 있지만 고도화를 원하는 환경까지, 모든 단계에 맞춘 아키텍처와 지원 체계, 스타터 킷을 제공합니다.</p>
+  </div>
+  <div class="offering-grid">
+    <div class="offering-card reveal">
+      <div class="offering-icon">🏗️</div>
+      <h3>Baseline for Building Full-stack AI Platform</h3>
+      <ul>
+        <li>GPU + 오픈소스 프레임워크 + AWS 서비스 조합 사전 검증된 레퍼런스 아키텍처</li>
+        <li>다양한 use case와 배포 옵션을 위한 유연·확장 가능 디자인 패턴</li>
+        <li>모델·에이전트에 대한 통합 액세스 셀프 서비스 포털</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🤝</div>
+      <h3>White-glove Support</h3>
+      <ul>
+        <li>AWS Specialist 기술 가이던스: Compute, K8S, Storage 등 전 영역</li>
+        <li>프로덕션 환경에서 GPU 가치 극대화 위한 베스트 프랙티스</li>
+        <li>AWS, 온프레미스, 엣지 전반의 배포 지원</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🛍️</div>
+      <h3>Open-source via AWS Marketplace</h3>
+      <ul>
+        <li>OSS 전문가가 사전 구성·최적화한 스택</li>
+        <li>1-Click Launch로 AMI 즉시 배포 (이종 소스 통합 코드 작성 스킵)</li>
+        <li>보안·거버넌스 강화 Enterprise Edition 또는 BYOL 옵션</li>
+      </ul>
+    </div>
+    <div class="offering-card reveal">
+      <div class="offering-icon">🚀</div>
+      <h3>Production-ready Starter Kit</h3>
+      <ul>
+        <li>엔터프라이즈 AI 배포를 가속하는 GenAI 인프라 툴킷</li>
+        <li>AI Gateway, LLM Serving, Vector DB, Embedding Models, E2E Observability 포함</li>
+        <li>박스 오픈 즉시 프로덕션 환경에 적용 가능</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- 8. CUSTOMER STORIES - PLACEHOLDER -->
+<section id="customers">
+  <div class="reveal">
+    <div class="section-label">CUSTOMER STORIES</div>
+    <h2 class="section-title">고객 사례</h2>
+    <p class="section-desc">FlexAI 접근법을 통해 AI 인프라 전략을 재정의하고 있는 고객들의 이야기를 곧 만나보실 수 있습니다.</p>
+  </div>
+  <div class="customers-placeholder reveal">
+    <div class="image-placeholder-icon">📋</div>
+    <div class="image-placeholder-text">[ Customer Stories - 추후 추가 예정 ]</div>
+  </div>
+</section>
+
+<!-- 9. CONTACT -->
+<section id="contact">
+  <div class="contact-layout">
+    <div class="contact-info reveal">
+      <div class="section-label">GET IN TOUCH</div>
+      <h2>문의하기</h2>
+      <p>솔루션에 관심이 있으시면 아래 채널 또는 담당 AWS 어카운트 팀(SA / TAM)을 통해 연락 부탁드립니다.</p>
+      <div class="contact-emails">
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">🐙</span>
+          <div class="contact-email-text">GitHub Issues</div>
+        </a>
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">💬</span>
+          <div class="contact-email-text">GitHub Discussions</div>
+        </a>
+        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
+          <span class="contact-email-icon">⭐</span>
+          <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
+        </a>
+      </div>
+    </div>
+    <div class="contact-form-wrapper reveal">
+      <div class="form-title">문의 양식</div>
+      <div class="form-group">
+        <label>성함 *</label>
+        <input type="text" placeholder="홍길동">
+      </div>
+      <div class="form-group">
+        <label>회사명 / 직책 *</label>
+        <input type="text" placeholder="회사명, 직책">
+      </div>
+      <div class="form-group">
+        <label>이메일 *</label>
+        <input type="email" placeholder="example@company.com">
+      </div>
+      <div class="form-group">
+        <label>문의 내용</label>
+        <textarea placeholder="현재 환경, 도입 목적, 일정 등을 자유롭게 작성해주세요."></textarea>
+      </div>
+      <button class="form-submit" onclick="window.open('https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues/new', '_blank')">GitHub 이슈로 문의하기 →</button>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="footer-logo">© 2026 Amazon Web Services, Inc.</div>
+  <div>Architecting Flexible AI Platform on AWS</div>
+  <div>Run Any Model, Anywhere.</div>
+</footer>
+
+<script>
+  const reveals = document.querySelectorAll('.reveal');
+  const observer = new IntersectionObserver((entries) => {
+    entries.forEach((entry, i) => {
+      if (entry.isIntersecting) {
+        setTimeout(() => entry.target.classList.add('visible'), i * 50);
+        observer.unobserve(entry.target);
+      }
+    });
+  }, { threshold: 0.1 });
+  reveals.forEach(el => observer.observe(el));
+</script>
+</body>
+</html>

--- a/docs/flex-ai/landing.html
+++ b/docs/flex-ai/landing.html
@@ -789,45 +789,23 @@
 
 <!-- 9. CONTACT -->
 <section id="contact">
-  <div class="contact-layout">
-    <div class="contact-info reveal">
-      <div class="section-label">GET IN TOUCH</div>
-      <h2>문의하기</h2>
-      <p>솔루션에 관심이 있으시면 아래 채널 또는 담당 AWS 어카운트 팀(SA / TAM)을 통해 연락 부탁드립니다.</p>
-      <div class="contact-emails">
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">🐙</span>
-          <div class="contact-email-text">GitHub Issues</div>
-        </a>
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">💬</span>
-          <div class="contact-email-text">GitHub Discussions</div>
-        </a>
-        <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
-          <span class="contact-email-icon">⭐</span>
-          <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
-        </a>
-      </div>
-    </div>
-    <div class="contact-form-wrapper reveal">
-      <div class="form-title">문의 양식</div>
-      <div class="form-group">
-        <label>성함 *</label>
-        <input type="text" placeholder="홍길동">
-      </div>
-      <div class="form-group">
-        <label>회사명 / 직책 *</label>
-        <input type="text" placeholder="회사명, 직책">
-      </div>
-      <div class="form-group">
-        <label>이메일 *</label>
-        <input type="email" placeholder="example@company.com">
-      </div>
-      <div class="form-group">
-        <label>문의 내용</label>
-        <textarea placeholder="현재 환경, 도입 목적, 일정 등을 자유롭게 작성해주세요."></textarea>
-      </div>
-      <button class="form-submit" onclick="window.open('https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues/new', '_blank')">GitHub 이슈로 문의하기 →</button>
+  <div class="contact-info reveal" style="max-width: 820px; margin: 0 auto; text-align: center;">
+    <div class="section-label">GET IN TOUCH</div>
+    <h2>문의하기</h2>
+    <p style="margin-left: auto; margin-right: auto;">솔루션에 관심이 있으시면 아래 GitHub 채널을 이용하시거나, 담당 AWS 어카운트 팀(SA / TAM)을 통해 연락 부탁드립니다.</p>
+    <div class="contact-emails" style="max-width: 520px; margin: 0 auto;">
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/discussions/categories/q-a" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">💬</span>
+        <div class="contact-email-text">GitHub Discussions · Q&amp;A</div>
+      </a>
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit/issues" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">🐙</span>
+        <div class="contact-email-text">GitHub Issues</div>
+      </a>
+      <a href="https://github.com/aws-samples/sample-genai-on-eks-starter-kit" class="contact-email" target="_blank" rel="noopener">
+        <span class="contact-email-icon">⭐</span>
+        <div class="contact-email-text">aws-samples/sample-genai-on-eks-starter-kit</div>
+      </a>
     </div>
   </div>
 </section>

--- a/docs/flex-ai/landing.html
+++ b/docs/flex-ai/landing.html
@@ -232,7 +232,7 @@
   }
   .flex-card p { font-size: 12px; color: var(--aws-muted); line-height: 1.6; }
 
-  /* FUNCTIONAL VIEW - placeholder */
+  /* FUNCTIONAL VIEW */
   #functional { background: var(--aws-dark); }
   .image-placeholder {
     background: var(--aws-navy);
@@ -245,6 +245,19 @@
   }
   .image-placeholder-icon { font-size: 48px; opacity: 0.5; }
   .image-placeholder-text { font-size: 14px; font-family: var(--font-display); letter-spacing: 0.05em; }
+  .arch-diagram {
+    background: var(--aws-navy);
+    border: 1px solid var(--aws-border);
+    border-radius: 12px;
+    padding: 24px;
+    overflow: hidden;
+  }
+  .arch-diagram svg { width: 100%; height: auto; display: block; }
+  .arch-caption {
+    margin-top: 16px; text-align: center;
+    font-family: var(--font-display); font-size: 11px; letter-spacing: 0.08em;
+    color: var(--aws-muted); text-transform: uppercase;
+  }
 
   /* BENEFITS */
   #benefits {
@@ -636,10 +649,200 @@
     <h2 class="section-title">기능 구성 & 빌딩 블록</h2>
     <p class="section-desc">Application 레이어부터 Cloud·On-prem·Edge 인프라까지 전 계층을 포괄하는 구조. 환경에 맞춰 필요한 컴포넌트부터 점진적으로 확장하거나, 통합 플랫폼으로 한 번에 구축할 수 있습니다.</p>
   </div>
-  <div class="image-placeholder reveal">
-    <div class="image-placeholder-icon">🖼️</div>
-    <div class="image-placeholder-text">[ 다이어그램 이미지 영역 ]</div>
-    <div class="image-placeholder-text" style="font-size: 12px; opacity: 0.6;">이미지 파일을 첨부하면 이 자리에 들어갑니다</div>
+  <div class="arch-diagram reveal">
+    <svg viewBox="0 0 1400 940" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid meet" role="img" aria-label="Flexible AI 레이어 아키텍처 다이어그램">
+      <defs>
+        <linearGradient id="layerOrange" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#FF9900" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#FF9900" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerBlue" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#4A9EE7" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#4A9EE7" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerPurple" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#A78BFA" stop-opacity="0.10"/>
+          <stop offset="100%" stop-color="#A78BFA" stop-opacity="0.02"/>
+        </linearGradient>
+        <linearGradient id="layerGreen" x1="0%" y1="0%" x2="100%" y2="0%">
+          <stop offset="0%" stop-color="#34D399" stop-opacity="0.08"/>
+          <stop offset="100%" stop-color="#34D399" stop-opacity="0.02"/>
+        </linearGradient>
+        <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
+          <path d="M 0 0 L 10 5 L 0 10 z" fill="#8BA3BE"/>
+        </marker>
+      </defs>
+
+      <style>
+        .layer-label { font-family: 'DM Mono', monospace; font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase; }
+        .node-title { font-family: 'Noto Sans KR', sans-serif; font-size: 13px; font-weight: 700; fill: #E8EFF7; }
+        .node-sub { font-family: 'Noto Sans KR', sans-serif; font-size: 10px; fill: #8BA3BE; }
+        .node-rect { fill: #1A2B45; stroke: rgba(255,255,255,0.12); stroke-width: 1; rx: 8; ry: 8; }
+        .node-rect.orange { stroke: rgba(255,153,0,0.45); }
+        .node-rect.blue { stroke: rgba(74,158,231,0.45); }
+        .node-rect.purple { stroke: rgba(167,139,250,0.45); }
+        .node-rect.green { stroke: rgba(52,211,153,0.45); }
+        .flow { stroke: #8BA3BE; stroke-width: 1.2; fill: none; opacity: 0.55; }
+      </style>
+
+      <!-- Layer 1 - Users & Clients (top) -->
+      <rect x="40" y="30" width="1320" height="110" fill="url(#layerOrange)" rx="12" ry="12"/>
+      <text x="60" y="55" class="layer-label" fill="#FF9900">USERS &amp; CLIENTS</text>
+      <g transform="translate(80,75)">
+        <rect class="node-rect orange" width="240" height="50"/>
+        <text x="20" y="22" class="node-title">Open WebUI</text>
+        <text x="20" y="38" class="node-sub">Self-service portal · Chat UI</text>
+      </g>
+      <g transform="translate(360,75)">
+        <rect class="node-rect orange" width="280" height="50"/>
+        <text x="20" y="22" class="node-title">Custom Apps &amp; Agents</text>
+        <text x="20" y="38" class="node-sub">SDK / API consumers</text>
+      </g>
+      <g transform="translate(680,75)">
+        <rect class="node-rect orange" width="220" height="50"/>
+        <text x="20" y="22" class="node-title">Workflow Automation</text>
+        <text x="20" y="38" class="node-sub">n8n</text>
+      </g>
+      <g transform="translate(940,75)">
+        <rect class="node-rect orange" width="380" height="50"/>
+        <text x="20" y="22" class="node-title">Workshop / Reference</text>
+        <text x="20" y="38" class="node-sub">eks-genai-workshop · Loan Buddy</text>
+      </g>
+
+      <!-- Layer 2 - Gateway & Guardrails -->
+      <rect x="40" y="170" width="1320" height="110" fill="url(#layerBlue)" rx="12" ry="12"/>
+      <text x="60" y="195" class="layer-label" fill="#4A9EE7">GATEWAY &amp; GUARDRAILS</text>
+      <g transform="translate(80,215)">
+        <rect class="node-rect blue" width="380" height="50"/>
+        <text x="20" y="22" class="node-title">AI Gateway</text>
+        <text x="20" y="38" class="node-sub">LiteLLM · Kong AI Gateway OSS</text>
+      </g>
+      <g transform="translate(500,215)">
+        <rect class="node-rect blue" width="260" height="50"/>
+        <text x="20" y="22" class="node-title">Guardrails</text>
+        <text x="20" y="38" class="node-sub">Guardrails AI</text>
+      </g>
+      <g transform="translate(800,215)">
+        <rect class="node-rect blue" width="520" height="50"/>
+        <text x="20" y="22" class="node-title">Routing &amp; Policy</text>
+        <text x="20" y="38" class="node-sub">Workload-optimized routing · Centralized policy management</text>
+      </g>
+
+      <!-- Layer 3 - Agentic Layer -->
+      <rect x="40" y="310" width="1320" height="140" fill="url(#layerPurple)" rx="12" ry="12"/>
+      <text x="60" y="335" class="layer-label" fill="#A78BFA">AGENTIC LAYER</text>
+      <g transform="translate(80,355)">
+        <rect class="node-rect purple" width="320" height="80"/>
+        <text x="20" y="24" class="node-title">Agent Frameworks</text>
+        <text x="20" y="42" class="node-sub">LangGraph · Strands · Agno</text>
+        <text x="20" y="58" class="node-sub">OpenClaw · Bedrock AgentCore</text>
+      </g>
+      <g transform="translate(440,355)">
+        <rect class="node-rect purple" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">MCP / A2A</text>
+        <text x="20" y="42" class="node-sub">FastMCP 2.0</text>
+        <text x="20" y="58" class="node-sub">Tool servers · Agent-to-agent</text>
+      </g>
+      <g transform="translate(720,355)">
+        <rect class="node-rect purple" width="320" height="80"/>
+        <text x="20" y="24" class="node-title">Retrieval &amp; Memory</text>
+        <text x="20" y="42" class="node-sub">Qdrant · Chroma · Milvus</text>
+        <text x="20" y="58" class="node-sub">S3 Vectors · Mem0</text>
+      </g>
+      <g transform="translate(1080,355)">
+        <rect class="node-rect purple" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">Reference Apps</text>
+        <text x="20" y="42" class="node-sub">Calculator agents</text>
+        <text x="20" y="58" class="node-sub">DevOps / Doc Writer</text>
+      </g>
+
+      <!-- Layer 4 - Model Serving -->
+      <rect x="40" y="480" width="1320" height="140" fill="url(#layerOrange)" rx="12" ry="12"/>
+      <text x="60" y="505" class="layer-label" fill="#FF9900">MODEL SERVING</text>
+      <g transform="translate(80,525)">
+        <rect class="node-rect orange" width="340" height="80"/>
+        <text x="20" y="24" class="node-title">Self-hosted LLM</text>
+        <text x="20" y="42" class="node-sub">vLLM · SGLang · TGI · Ollama</text>
+        <text x="20" y="58" class="node-sub">Ray · NVIDIA Dynamo Platform</text>
+      </g>
+      <g transform="translate(460,525)">
+        <rect class="node-rect orange" width="240" height="80"/>
+        <text x="20" y="24" class="node-title">Embedding</text>
+        <text x="20" y="42" class="node-sub">Text Embedding Inference</text>
+        <text x="20" y="58" class="node-sub">(TEI)</text>
+      </g>
+      <g transform="translate(740,525)">
+        <rect class="node-rect orange" width="280" height="80"/>
+        <text x="20" y="24" class="node-title">AWS Managed</text>
+        <text x="20" y="42" class="node-sub">Amazon Bedrock</text>
+        <text x="20" y="58" class="node-sub">Nova · SageMaker</text>
+      </g>
+      <g transform="translate(1060,525)">
+        <rect class="node-rect orange" width="260" height="80"/>
+        <text x="20" y="24" class="node-title">External LLM</text>
+        <text x="20" y="42" class="node-sub">OpenAI · Anthropic</text>
+        <text x="20" y="58" class="node-sub">Gemini · others</text>
+      </g>
+
+      <!-- Layer 5 - Observability -->
+      <rect x="40" y="650" width="1320" height="80" fill="url(#layerGreen)" rx="12" ry="12"/>
+      <text x="60" y="675" class="layer-label" fill="#34D399">OBSERVABILITY</text>
+      <g transform="translate(80,690)">
+        <rect class="node-rect green" width="380" height="30"/>
+        <text x="20" y="20" class="node-title">Langfuse</text>
+        <text x="160" y="20" class="node-sub">tracing · session/tag</text>
+      </g>
+      <g transform="translate(500,690)">
+        <rect class="node-rect green" width="380" height="30"/>
+        <text x="20" y="20" class="node-title">Phoenix</text>
+        <text x="160" y="20" class="node-sub">evaluation · monitoring</text>
+      </g>
+      <g transform="translate(920,690)">
+        <rect class="node-rect green" width="400" height="30"/>
+        <text x="20" y="20" class="node-title">MLflow</text>
+        <text x="160" y="20" class="node-sub">experiment tracking</text>
+      </g>
+
+      <!-- Layer 6 - Compute & Infrastructure -->
+      <rect x="40" y="760" width="1320" height="160" fill="url(#layerBlue)" rx="12" ry="12"/>
+      <text x="60" y="785" class="layer-label" fill="#4A9EE7">COMPUTE &amp; INFRASTRUCTURE</text>
+      <g transform="translate(80,805)">
+        <rect class="node-rect blue" width="300" height="100"/>
+        <text x="20" y="24" class="node-title">Amazon EKS</text>
+        <text x="20" y="42" class="node-sub">Auto Mode · Standard</text>
+        <text x="20" y="58" class="node-sub">EKS Hybrid Node (on-prem)</text>
+        <text x="20" y="78" class="node-sub">Karpenter · NodePool</text>
+      </g>
+      <g transform="translate(420,805)">
+        <rect class="node-rect blue" width="300" height="100"/>
+        <text x="20" y="24" class="node-title">Heterogeneous Compute</text>
+        <text x="20" y="42" class="node-sub">GPU (g6e · g6 · g5g)</text>
+        <text x="20" y="58" class="node-sub">Trainium / Inferentia (inf2 · trn1)</text>
+        <text x="20" y="78" class="node-sub">Graviton (planning · CPU)</text>
+      </g>
+      <g transform="translate(760,805)">
+        <rect class="node-rect blue" width="280" height="100"/>
+        <text x="20" y="24" class="node-title">Storage &amp; Networking</text>
+        <text x="20" y="42" class="node-sub">EFS model cache · S3 Vectors</text>
+        <text x="20" y="58" class="node-sub">ALB Ingress + ACM</text>
+        <text x="20" y="78" class="node-sub">VPC · Private subnets</text>
+      </g>
+      <g transform="translate(1080,805)">
+        <rect class="node-rect blue" width="240" height="100"/>
+        <text x="20" y="24" class="node-title">Identity &amp; Secrets</text>
+        <text x="20" y="42" class="node-sub">IAM Roles for SA (IRSA)</text>
+        <text x="20" y="58" class="node-sub">AWS Secrets Manager</text>
+        <text x="20" y="78" class="node-sub">ECR + pull-through cache</text>
+      </g>
+
+      <!-- Vertical flow lines between layers -->
+      <line x1="700" y1="140" x2="700" y2="170" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="280" x2="700" y2="310" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="450" x2="700" y2="480" class="flow" marker-end="url(#arrow)"/>
+      <line x1="700" y1="620" x2="700" y2="650" class="flow" marker-end="url(#arrow)" stroke-dasharray="4 4"/>
+      <line x1="700" y1="730" x2="700" y2="760" class="flow" stroke-dasharray="4 4"/>
+    </svg>
+    <div class="arch-caption">현재 리포지토리에 포함된 컴포넌트 기준 · 카테고리별 단일 컴포넌트 또는 조합 선택 가능</div>
   </div>
 </section>
 

--- a/docs/flex-ai/use-cases.ko.md
+++ b/docs/flex-ai/use-cases.ko.md
@@ -1,0 +1,95 @@
+---
+title: Use Cases
+---
+
+[한국어](use-cases.ko.md){ .md-button .md-button--primary } [English](use-cases.md){ .md-button }
+
+# Key Use Cases
+
+GPU 기반 모델 서빙, AI Gateway, Observability 등 **공통 컴포넌트** 위에 use case별 컴포넌트를 조합하여 다양한 시나리오를 구현할 수 있습니다.
+
+## 01. Self-hosted Model Serving on AWS
+
+EKS 위에 self-hosted 모델 서빙 환경을 구축합니다.
+
+- **AI Gateway**: LiteLLM · Kong
+- **Inference Engines**: Ray · SGLang · vLLM
+- **Observability**: Langfuse · MLflow
+- **Vector DB**: Qdrant · Chroma · Milvus
+
+HuggingFace 네이티브 연동으로 신규 모델에 빠르게 접근하며, **데이터 주권**과 시스템부터 AI 레벨까지의 **Enhanced Observability**를 확보합니다.
+
+## 02. Hybrid Model Serving
+
+Self-hosted, AWS-managed(Bedrock·Nova·SageMaker), 외부 모델(OpenAI·Gemini·Anthropic)을 단일 플랫폼에서 통합 운영합니다.
+
+- AI Gateway가 **workload-optimized routing**을 수행 — 워크로드별 최적 모델로 코드 변경 없이 라우팅.
+- **Centralized policy management**로 거버넌스 유지.
+
+## 03. Agentic AI
+
+AWS Native(Bedrock·Strands·AgentCore)로 시작해 EKS 기반 Self-hosted로 확장합니다.
+
+- **Custom Agent workflow**: LangGraph · MCP / A2A.
+- **도메인 특화 SLM**을 자유롭게 결합.
+- **Heterogeneous Compute Allocation**: Graviton (planning), GPU (reasoning), Trainium / Inferentia (inference) — 비용 최적화.
+
+레퍼런스 워크로드는 [Loan Buddy 에이전트](../examples/strands-agents/calculator-agent.md), [OpenClaw DevOps Agent](../examples/openclaw/devops-agent.md), [OpenClaw Document Writer](../examples/openclaw/doc-writer.md)에서 확인 가능합니다.
+
+## 04. Hybrid Cluster
+
+AWS Cloud와 On-prem을 **EKS Hybrid Node**로 연결하는 단일 클러스터.
+
+- 규제·민감 워크로드는 온프레미스, 나머지는 AWS에서 처리.
+- 장애 시 AWS로 자동 fallback.
+- **온프렘 학습 + AWS 글로벌 추론** 시나리오도 재설계 없이 구현.
+
+## 05. Cost Optimization with Trainium / Inferentia
+
+AWS 자체 AI 칩으로 동급 EC2 대비 최대 **40-60% 비용 절감**과 업계 최고 수준의 OTPS 달성.
+
+- PyTorch 네이티브 지원과 **Neuron Kernel Interface**를 통한 fine-grained 튜닝.
+- **Neuron Explorer**를 통한 실행 흐름 추적.
+
+# Key Benefits
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Run Any Model Anywhere**
+
+    ---
+
+    - 통합 액세스 제어 (Unified access control)
+    - 벤더 락인 제거
+    - 데이터 레지던시 및 규제 준수
+    - Self-hosted 모델, Amazon 관리형 서비스(Bedrock), 외부 LLM 호출까지 유연하게 이용
+    - Self-service portal
+
+-   :material-cash-multiple:{ .lg .middle } **Optimize Costs**
+
+    ---
+
+    - 모델 및 GPU 활용 최적화
+    - 이기종 컴퓨팅(GPU / Trainium / Graviton)을 워크로드별로 적용·오케스트레이션
+    - Amazon Bedrock에서 Self-hosted로의 매끄러운 마이그레이션 지원
+
+-   :material-shield-check-outline:{ .lg .middle } **Protect Existing AI Investment**
+
+    ---
+
+    - 온프레미스 환경에 **Bolt-on** 방식으로 적용 가능
+    - 재설계(Re-architecting) 없이 하이브리드 배포
+    - 온프레미스·클라우드 GPU 통합 관리
+
+-   :material-robot-outline:{ .lg .middle } **Agentic AI & Compute Modernization**
+
+    ---
+
+    - 자율 에이전트 운영을 위한 통합 환경
+    - 인프라·에이전트 행동·아웃풋에 대한 **E2E Observability**
+    - 워크플로우 코드 레벨 완전 제어
+
+</div>
+
+[:octicons-arrow-right-24: Get Started](get-started.ko.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Architecture](architecture.ko.md){ .md-button }

--- a/docs/flex-ai/use-cases.md
+++ b/docs/flex-ai/use-cases.md
@@ -1,0 +1,95 @@
+---
+title: Use Cases
+---
+
+[한국어](use-cases.ko.md){ .md-button } [English](use-cases.md){ .md-button .md-button--primary }
+
+# Key Use Cases
+
+GPU-backed model serving, AI gateway, and observability are **shared building blocks**. Compose them with use-case-specific components to fit a wide range of scenarios.
+
+## 01. Self-hosted Model Serving on AWS
+
+Stand up a self-hosted model serving environment on EKS.
+
+- **AI Gateway**: LiteLLM, Kong.
+- **Inference Engines**: Ray, SGLang, vLLM.
+- **Observability**: Langfuse, MLflow.
+- **Vector DB**: Qdrant, Chroma, Milvus.
+
+Native HuggingFace integration keeps you close to the latest models. The result is **data sovereignty** plus **enhanced observability** spanning system metrics through to AI-level signals.
+
+## 02. Hybrid Model Serving
+
+Run self-hosted, AWS-managed (Bedrock, Nova, SageMaker), and external (OpenAI, Gemini, Anthropic) models on a single platform.
+
+- The AI gateway performs **workload-optimized routing** — switch models per workload without code changes.
+- **Centralized policy management** keeps governance consistent across providers.
+
+## 03. Agentic AI
+
+Start with AWS-native agent runtimes (Bedrock, Strands, AgentCore), then extend into self-hosted on EKS.
+
+- **Custom agent workflows**: LangGraph, MCP / A2A.
+- Combine with **domain-specific small language models**.
+- **Heterogeneous compute allocation** — Graviton for planning, GPU for reasoning, Trainium / Inferentia for inference — to optimize cost.
+
+Reference workloads: the [Loan Buddy agent](../examples/strands-agents/calculator-agent.md), [OpenClaw DevOps Agent](../examples/openclaw/devops-agent.md), and [OpenClaw Document Writer](../examples/openclaw/doc-writer.md).
+
+## 04. Hybrid Cluster
+
+Connect AWS Cloud and on-premises into a single cluster via **EKS Hybrid Node**.
+
+- Regulated and sensitive workloads stay on-prem; the rest run on AWS.
+- Automatic fallback to AWS during on-prem incidents.
+- "Train on-prem, serve globally on AWS" works without re-architecting.
+
+## 05. Cost Optimization with Trainium / Inferentia
+
+AWS purpose-built AI silicon delivers up to **40-60% cost savings** versus comparable EC2 instances and industry-leading OTPS.
+
+- Native PyTorch support and the **Neuron Kernel Interface** for fine-grained tuning.
+- **Neuron Explorer** for execution-flow tracing.
+
+# Key Benefits
+
+<div class="grid cards" markdown>
+
+-   :material-rocket-launch:{ .lg .middle } **Run Any Model Anywhere**
+
+    ---
+
+    - Unified access control
+    - No vendor lock-in
+    - Data residency and regulatory compliance
+    - Self-hosted models, AWS-managed services (Bedrock), and external LLMs — all reachable
+    - Self-service portal
+
+-   :material-cash-multiple:{ .lg .middle } **Optimize Costs**
+
+    ---
+
+    - Optimize model and GPU utilization
+    - Apply and orchestrate heterogeneous compute (GPU / Trainium / Graviton) per workload
+    - Smooth migration path from Amazon Bedrock to self-hosted
+
+-   :material-shield-check-outline:{ .lg .middle } **Protect Existing AI Investment**
+
+    ---
+
+    - **Bolt-on** to existing on-prem environments
+    - Hybrid deployment without re-architecting
+    - Unified management across on-prem and cloud GPUs
+
+-   :material-robot-outline:{ .lg .middle } **Agentic AI & Compute Modernization**
+
+    ---
+
+    - One environment for autonomous agent operations
+    - **End-to-end observability** across infrastructure, agent behavior, and outputs
+    - Full code-level control over workflows
+
+</div>
+
+[:octicons-arrow-right-24: Get Started](get-started.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Architecture](architecture.md){ .md-button }

--- a/docs/flex-ai/why.ko.md
+++ b/docs/flex-ai/why.ko.md
@@ -1,0 +1,80 @@
+---
+title: Why Flex AI
+---
+
+[한국어](why.ko.md){ .md-button .md-button--primary } [English](why.md){ .md-button }
+
+# Value Proposition
+
+Flex AI는 다섯 가지 가치 축으로 구성된 통합 AI 플랫폼입니다.
+
+<div class="grid cards" markdown>
+
+-   :material-tune-variant:{ .lg .middle } **Customization & Flexibility**
+
+    ---
+
+    AI 스택의 모든 레이어를 비즈니스 요구에 맞춰 자유롭게 선택하고 제어할 수 있습니다. 오픈소스와 프로프라이어터리 모델을 자유롭게 조합하고, 선호하는 프레임워크를 mix and match하며, 모델 가중치부터 데이터 흐름, 인프라 구성까지 완전한 가시성과 제어권을 확보하세요. 신규 모델이 출시되면 라우팅 추가만으로 즉시 도입할 수 있어 AI 혁신 사이클이 가속됩니다.
+
+-   :material-shield-lock-outline:{ .lg .middle } **Sovereignty & Compliance**
+
+    ---
+
+    데이터 레지던시 및 컴플라이언스를 충족합니다. 민감 정보가 외부로 노출되거나 타 고객 GPU 리소스와 공유될 우려 없이, 데이터 주권을 유지하면서 최신 AI 기술을 도입할 수 있습니다.
+
+-   :material-currency-usd:{ .lg .middle } **Cost Efficiency**
+
+    ---
+
+    워크로드별로 최적의 컴퓨트 — GPU, Trainium, Inferentia, Graviton — 를 자유롭게 조합하여 동급 EC2 대비 최대 40-60% 비용을 절감합니다. 토큰 기반 가격과 GPUaaS 모델 사이를 유연하게 전환하여 인프라 지출을 실제 비즈니스 가치에 직접 연동할 수 있습니다.
+
+-   :material-magnify-scan:{ .lg .middle } **E2E Observability**
+
+    ---
+
+    인프라, 모델, 에이전트 동작, 비용까지 — AI 워크로드의 모든 계층을 단일 화면에서 모니터링합니다. GPU 활용률과 시스템 성능부터 프롬프트별 응답 품질, 모델·팀·프로젝트 단위 세분화된 비용 추적까지, 운영에 필요한 모든 신호를 코드 레벨로 확보합니다.
+
+-   :material-rocket-launch-outline:{ .lg .middle } **Faster Time-to-Value**
+
+    ---
+
+    사전 검증된 레퍼런스 아키텍처와 도입 가이던스를 통해 PoC에서 프로덕션까지의 여정을 수개월에서 수주로 단축합니다. 처음부터 다시 설계할 필요 없이, AWS와 검증된 오픈소스 생태계 위에서 즉시 구축을 시작할 수 있습니다.
+
+</div>
+
+# 5가지 차원의 유연성
+
+AI 인프라의 모든 측면에서 유연성을 제공합니다. 비용·성능·거버넌스 요구가 변화할 때 전체 아키텍처를 다시 설계할 필요 없이, 각 차원에서 자유롭게 전환할 수 있습니다.
+
+## 1. 이기종 컴퓨트 선택 (Heterogeneous Compute Choice)
+
+> *어떤 실리콘을 사용할 것인가?*
+
+GPU, AWS Inferentia/Trainium, Graviton 중 워크로드 특성에 맞는 최적의 컴퓨팅을 자유롭게 선택. 단일 칩이나 인스턴스 유형에 종속되지 않습니다.
+
+## 2. Self-Hosted 완전 제어 (Self-Hosted Control)
+
+> *어떻게 배포할 것인가?*
+
+오픈소스 프레임워크를 직접 배포·운영하여 모델 가중치, 데이터 흐름, 인프라 구성에 대한 완전한 가시성과 통제권을 확보합니다.
+
+## 3. 유연한 소비 모델 (Flexible Consumption Models)
+
+> *어떻게 비용을 지불할 것인가?*
+
+토큰 기반 과금과 시간당 GPU 과금 사이를 자유롭게 전환. 인프라 비용을 비즈니스 가치와 직접 연동합니다.
+
+## 4. 하이브리드 배포 민첩성 (Hybrid Deployment Agility)
+
+> *어디에 배포할 것인가?*
+
+온프레미스, EC2 기반 Self-hosted, Amazon Bedrock, 외부 LLM을 재설계 없이 유동적으로 이동합니다.
+
+## 5. 통합 풀스택 가이던스 (Integrated Full-Stack Guidance)
+
+> *어디서부터 시작할 것인가?*
+
+모델 최적화부터 스토리지, 플랫폼 엔지니어링, 에이전틱 애플리케이션까지 전체를 아우르는 통합 아키텍처 패턴을 제공합니다. 고객의 현황과 비즈니스 요구사항에 맞게 점진적 도입이 가능합니다.
+
+[:octicons-arrow-right-24: Architecture](architecture.ko.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Use Cases](use-cases.ko.md){ .md-button }

--- a/docs/flex-ai/why.ko.md
+++ b/docs/flex-ai/why.ko.md
@@ -1,12 +1,12 @@
 ---
-title: Why Flex AI
+title: Why Flexible AI
 ---
 
 [한국어](why.ko.md){ .md-button .md-button--primary } [English](why.md){ .md-button }
 
 # Value Proposition
 
-Flex AI는 다섯 가지 가치 축으로 구성된 통합 AI 플랫폼입니다.
+Flexible AI는 다섯 가지 가치 축으로 구성된 통합 AI 플랫폼입니다.
 
 <div class="grid cards" markdown>
 

--- a/docs/flex-ai/why.md
+++ b/docs/flex-ai/why.md
@@ -1,12 +1,12 @@
 ---
-title: Why Flex AI
+title: Why Flexible AI
 ---
 
 [한국어](why.ko.md){ .md-button } [English](why.md){ .md-button .md-button--primary }
 
 # Value Proposition
 
-Flex AI is built around five value pillars.
+Flexible AI is built around five value pillars.
 
 <div class="grid cards" markdown>
 
@@ -44,7 +44,7 @@ Flex AI is built around five value pillars.
 
 # Five Dimensions of Flexibility
 
-Flex AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, you switch on the relevant axis instead of redesigning the whole architecture.
+Flexible AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, you switch on the relevant axis instead of redesigning the whole architecture.
 
 ## 1. Heterogeneous Compute Choice
 

--- a/docs/flex-ai/why.md
+++ b/docs/flex-ai/why.md
@@ -1,0 +1,80 @@
+---
+title: Why Flex AI
+---
+
+[한국어](why.ko.md){ .md-button } [English](why.md){ .md-button .md-button--primary }
+
+# Value Proposition
+
+Flex AI is built around five value pillars.
+
+<div class="grid cards" markdown>
+
+-   :material-tune-variant:{ .lg .middle } **Customization & Flexibility**
+
+    ---
+
+    Every layer of the AI stack is composable. Mix open-source and proprietary models, mix-and-match frameworks, and keep full visibility and control over weights, data flows, and infrastructure. New model out today? Add a route — innovation cycles stop being blocked on platform rework.
+
+-   :material-shield-lock-outline:{ .lg .middle } **Sovereignty & Compliance**
+
+    ---
+
+    Meet data residency and compliance requirements without sacrificing access to modern AI. Sensitive data does not leave the customer boundary, and GPUs are not shared with other tenants.
+
+-   :material-currency-usd:{ .lg .middle } **Cost Efficiency**
+
+    ---
+
+    Compose the right compute per workload — GPU, Trainium, Inferentia, Graviton — and realize up to **40-60% savings** versus comparable EC2 instances. Move freely between token-based pricing and GPU-as-a-service so infrastructure spend tracks business value, not abstractions.
+
+-   :material-magnify-scan:{ .lg .middle } **E2E Observability**
+
+    ---
+
+    One pane of glass across infrastructure, models, agent behavior, and cost. From GPU utilization and system performance, through per-prompt response quality, to fine-grained cost attribution by model, team, or project — every operational signal is available at the code level.
+
+-   :material-rocket-launch-outline:{ .lg .middle } **Faster Time-to-Value**
+
+    ---
+
+    Pre-validated reference architectures and adoption guidance compress the PoC-to-production journey from months to weeks. Don't redesign from scratch — start building on top of AWS and a proven OSS ecosystem.
+
+</div>
+
+# Five Dimensions of Flexibility
+
+Flex AI delivers flexibility on every axis. When cost, performance, or governance requirements shift, you switch on the relevant axis instead of redesigning the whole architecture.
+
+## 1. Heterogeneous Compute Choice
+
+> *Which silicon do you run on?*
+
+Pick the optimal compute per workload across GPU, AWS Inferentia / Trainium, and Graviton. No lock-in to a single chip family or instance type.
+
+## 2. Self-Hosted Control
+
+> *How do you deploy?*
+
+Run open-source frameworks under your own control to keep full visibility and authority over model weights, data flows, and infrastructure layout.
+
+## 3. Flexible Consumption Models
+
+> *How do you pay for it?*
+
+Move between token-based pricing and per-hour GPU pricing as the workload demands. Tie infrastructure cost directly to business value.
+
+## 4. Hybrid Deployment Agility
+
+> *Where do you deploy?*
+
+Move workloads between on-premises, EC2 self-hosted, Amazon Bedrock, and external LLM providers without re-architecting.
+
+## 5. Integrated Full-Stack Guidance
+
+> *Where do you start?*
+
+Reference patterns covering model optimization, storage, platform engineering, and agentic applications. Adopt incrementally — pick the layer that matches the customer's current state and grow from there.
+
+[:octicons-arrow-right-24: Architecture](architecture.md){ .md-button .md-button--primary }
+[:octicons-arrow-right-24: Use Cases](use-cases.md){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,18 +74,18 @@ extra:
 
 nav:
   - Home: index.md
-  - Flex AI:
+  - Flexible AI:
     - Landing (KO): flex-ai/landing.html
     - Landing (EN): flex-ai/landing.en.html
     - Docs (English):
       - Overview: flex-ai/index.md
-      - Why Flex AI: flex-ai/why.md
+      - Why Flexible AI: flex-ai/why.md
       - Architecture: flex-ai/architecture.md
       - Use Cases: flex-ai/use-cases.md
       - Get Started: flex-ai/get-started.md
     - Docs (한국어):
       - 개요: flex-ai/index.ko.md
-      - Why Flex AI: flex-ai/why.ko.md
+      - Why Flexible AI: flex-ai/why.ko.md
       - 아키텍처: flex-ai/architecture.ko.md
       - 활용 사례: flex-ai/use-cases.ko.md
       - 시작하기: flex-ai/get-started.ko.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,21 @@ extra:
 
 nav:
   - Home: index.md
+  - Flex AI:
+    - Landing (KO): flex-ai/landing.html
+    - Landing (EN): flex-ai/landing.en.html
+    - Docs (English):
+      - Overview: flex-ai/index.md
+      - Why Flex AI: flex-ai/why.md
+      - Architecture: flex-ai/architecture.md
+      - Use Cases: flex-ai/use-cases.md
+      - Get Started: flex-ai/get-started.md
+    - Docs (한국어):
+      - 개요: flex-ai/index.ko.md
+      - Why Flex AI: flex-ai/why.ko.md
+      - 아키텍처: flex-ai/architecture.ko.md
+      - 활용 사례: flex-ai/use-cases.ko.md
+      - 시작하기: flex-ai/get-started.ko.md
   - Getting Started:
     - Prerequisites: getting-started/prerequisites.md
     - Quick Start: getting-started/quick-start.md


### PR DESCRIPTION
## Summary

Adds a new **Flexible AI** section to the documentation site that frames this repository — components, automation, and the Workshop Studio workshop — as the reference implementation for *Architecting a Flexible AI Platform on AWS*.

The section is primarily a sales-kit / initiative landing for prospective adopters, complementing the existing technical docs.

## What's added

- **Standalone landing pages (KO + EN)** — `docs/flex-ai/landing.html`, `docs/flex-ai/landing.en.html` — preserving the dark-themed marketing layout, with a per-page language toggle and a layered architecture diagram (inline SVG) populated with the actual components shipped in this repo.
- **Five docs pages each in English and Korean** — overview, why, architecture, use cases, get started — under `docs/flex-ai/` with a per-page `한국어 | English` toggle.
- **`mkdocs.yml` nav** — new `Flexible AI` tab inserted between `Home` and `Getting Started`, with sub-trees for the standalone landings and the bilingual docs.

## Why

- New content is *initiative / value-prop* in tone — placing it on a separate top-level tab keeps the existing technical docs unchanged.
- Bilingual coverage (English primary per the project's GitHub-content language rule, Korean secondary for AWS Korea customer enablement) without introducing an i18n plugin — each page just provides a sibling file and a top-of-page button toggle.
- The standalone landing is served as static HTML inside the docs site, so it renders the original Vercel-style design 1:1 and stays out of the Material navigation chrome.

## Notable choices

- **No new plugins or theme changes.** Uses Material `grid cards`, admonitions, and `pymdownx.superfences` for Mermaid — all already enabled.
- **No backend on the inquiry section.** Landing pages route to GitHub Discussions Q&A and Issues; no email collection.
- **Inline SVG diagram** — no external image, scales responsively, matches the existing palette (orange / blue / purple / green) used elsewhere on the page.

## Live preview

While this PR is in review, a fork preview is hosted at:
- KO landing: https://devfloor9.github.io/sample-genai-on-eks-starter-kit/flex-ai/landing.html
- EN landing: https://devfloor9.github.io/sample-genai-on-eks-starter-kit/flex-ai/landing.en.html
- MkDocs section: https://devfloor9.github.io/sample-genai-on-eks-starter-kit/flex-ai/

After merge the canonical URLs will be on `aws-samples.github.io/sample-genai-on-eks-starter-kit/flex-ai/`.

## Test plan

- [x] `mkdocs build --strict` passes (zero broken links, all new pages picked up by nav).
- [x] Local `mkdocs serve` walkthrough — both landings render, language toggle works, internal links into `components/...`, `examples/...`, `getting-started/...` resolve, Mermaid diagram on `architecture.md` renders.
- [x] Light/dark theme toggle on the docs pages (Material default behavior preserved).
- [x] Confirmed no edits to existing pages, workflows, or component docs.

## Out of scope

- No changes to `.github/workflows/docs.yml`, the existing components, or the workshop content.
- Customer stories section is intentionally left as a "coming soon" admonition.