### PR TITLE
feat(o11y): add Amazon Managed Prometheus & Grafana (AMP/AMG) component

### DIFF
--- a/cli-menu.json
+++ b/cli-menu.json
@@ -42,7 +42,8 @@
       "components": [
         { "dir": "langfuse", "name": "Langfuse" },
         { "dir": "mlflow", "name": "MLflow" },
-        { "dir": "phoenix", "name": "Phoenix" }
+        { "dir": "phoenix", "name": "Phoenix" },
+        { "dir": "amp-amg", "name": "Amazon Managed Prometheus & Grafana (AMP/AMG)" }
       ]
     },
     { "dir": "gui-app", "name": "GUI App", "components": [{ "dir": "openwebui", "name": "Open WebUI" }] },

--- a/components/o11y/amp-amg/index.mjs
+++ b/components/o11y/amp-amg/index.mjs
@@ -1,0 +1,119 @@
+import { fileURLToPath } from "url";
+import path from "path";
+import fs from "fs";
+import handlebars from "handlebars";
+import { $ } from "zx";
+$.verbose = true;
+
+export const name = "Amazon Managed Prometheus & Grafana (AMP/AMG)";
+const __filename = fileURLToPath(import.meta.url);
+const DIR = path.dirname(__filename);
+let BASE_DIR;
+let config;
+let utils;
+
+const NAMESPACE = "opentelemetry";
+
+export async function init(_BASE_DIR, _config, _utils) {
+  BASE_DIR = _BASE_DIR;
+  config = _config;
+  utils = _utils;
+}
+
+export async function install() {
+  const requiredEnvVars = ["REGION", "EKS_CLUSTER_NAME"];
+  utils.checkRequiredEnvVars(requiredEnvVars);
+
+  console.log("\n========================================");
+  console.log("Installing AMP/AMG Monitoring Stack");
+  console.log("(Amazon Managed Prometheus + Grafana + ADOT Collector)");
+  console.log("========================================\n");
+
+  // Step 1: Provision AMP workspace, AMG workspace, IAM roles via Terraform
+  console.log("[1/3] Provisioning AMP/AMG infrastructure (Terraform)...");
+  await utils.terraform.apply(DIR);
+  const tfOutput = await utils.terraform.output(DIR, {});
+
+  const ampRemoteWriteEndpoint = tfOutput.amp_remote_write_endpoint.value;
+  const ampQueryEndpoint = tfOutput.amp_query_endpoint.value;
+  const amgEndpoint = tfOutput.amg_endpoint.value;
+  const ampWorkspaceId = tfOutput.amp_workspace_id.value;
+
+  console.log(`  AMP Workspace: ${ampWorkspaceId}`);
+  console.log(`  AMP Remote Write: ${ampRemoteWriteEndpoint}`);
+  console.log(`  AMG Endpoint: ${amgEndpoint}`);
+
+  // Step 2: Add ADOT Helm repo and deploy collector
+  console.log("\n[2/3] Deploying ADOT Collector...");
+  await $`helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts --force-update`;
+  await $`helm repo update open-telemetry`;
+
+  const valuesTemplatePath = path.join(DIR, "values.template.yaml");
+  const valuesRenderedPath = path.join(DIR, "values.rendered.yaml");
+  const valuesTemplateString = fs.readFileSync(valuesTemplatePath, "utf8");
+  const valuesTemplate = handlebars.compile(valuesTemplateString);
+  const valuesVars = {
+    AMP_REMOTE_WRITE_ENDPOINT: ampRemoteWriteEndpoint,
+    AWS_REGION: process.env.REGION,
+  };
+  fs.writeFileSync(valuesRenderedPath, valuesTemplate(valuesVars));
+
+  await $`helm upgrade --install adot-collector \
+    open-telemetry/opentelemetry-collector \
+    --namespace ${NAMESPACE} \
+    --create-namespace \
+    -f ${valuesRenderedPath} \
+    --wait --timeout 5m`;
+
+  console.log("  ✅ ADOT Collector deployed");
+
+  // Step 3: Print status and next steps
+  console.log("\n[3/3] Verifying deployment...");
+  await printStatus(ampQueryEndpoint, amgEndpoint);
+
+  console.log("\n========================================");
+  console.log("Next Steps");
+  console.log("========================================");
+  console.log(`1. Access AMG: ${amgEndpoint}`);
+  console.log("2. Add AMP as a data source in Grafana:");
+  console.log(`   - Type: Prometheus`);
+  console.log(`   - URL: ${ampQueryEndpoint}`);
+  console.log("   - Auth: SigV4 (auto-configured via AMG role)");
+  console.log("3. Import GenAI dashboards for vLLM/LiteLLM metrics");
+}
+
+async function printStatus(ampEndpoint, amgEndpoint) {
+  console.log("\n--- ADOT Collector Pods ---");
+  try {
+    await $`kubectl get pods -n ${NAMESPACE}`;
+  } catch {
+    console.log("  (No pods found)");
+  }
+
+  console.log("\n--- Endpoints ---");
+  console.log(`  AMP Query: ${ampEndpoint}`);
+  console.log(`  AMG Dashboard: ${amgEndpoint}`);
+}
+
+export async function uninstall() {
+  console.log("\nUninstalling AMP/AMG Monitoring Stack...");
+
+  // Remove ADOT collector
+  try {
+    await $`helm uninstall adot-collector --namespace ${NAMESPACE}`;
+    console.log("ADOT Collector uninstalled.");
+  } catch {
+    console.log("ADOT Collector not found or already removed.");
+  }
+
+  // Delete namespace
+  try {
+    await $`kubectl delete namespace ${NAMESPACE} --ignore-not-found`;
+  } catch {
+    // ignore
+  }
+
+  // Destroy Terraform resources (AMP, AMG, IAM)
+  await utils.terraform.destroy(DIR);
+  console.log("AMP/AMG infrastructure destroyed.");
+}

--- a/components/o11y/amp-amg/main.tf
+++ b/components/o11y/amp-amg/main.tf
@@ -1,0 +1,154 @@
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+variable "name" {
+  type    = string
+  default = "genai-on-eks"
+}
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.96.0"
+    }
+  }
+}
+provider "aws" {
+  region = var.region
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_eks_cluster" "this" {
+  name = var.name
+}
+
+# ─── Amazon Managed Prometheus ───────────────────────────────────
+resource "aws_prometheus_workspace" "this" {
+  alias = "${var.name}-amp"
+  tags = {
+    Component = "amp-amg"
+    Project   = var.name
+  }
+}
+
+# ─── IAM Role for ADOT Collector (remote-write to AMP) ──────────
+resource "aws_iam_role" "adot_collector" {
+  name = "${var.name}-${var.region}-adot-collector"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "pods.eks.amazonaws.com"
+      }
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "adot_amp_write" {
+  role = aws_iam_role.adot_collector.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "aps:RemoteWrite",
+          "aps:GetSeries",
+          "aps:GetLabels",
+          "aps:GetMetricMetadata"
+        ]
+        Resource = aws_prometheus_workspace.this.arn
+      }
+    ]
+  })
+}
+
+resource "aws_eks_pod_identity_association" "adot_collector" {
+  cluster_name    = var.name
+  namespace       = "opentelemetry"
+  service_account = "adot-collector"
+  role_arn        = aws_iam_role.adot_collector.arn
+}
+
+# ─── IAM Role for Amazon Managed Grafana ─────────────────────────
+resource "aws_iam_role" "amg" {
+  name = "${var.name}-${var.region}-amg-service"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = {
+        Service = "grafana.amazonaws.com"
+      }
+      Action = "sts:AssumeRole"
+      Condition = {
+        StringEquals = {
+          "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+        }
+      }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy" "amg_amp_read" {
+  role = aws_iam_role.amg.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "aps:QueryMetrics",
+          "aps:GetSeries",
+          "aps:GetLabels",
+          "aps:GetMetricMetadata",
+          "aps:ListWorkspaces",
+          "aps:DescribeWorkspace"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+}
+
+resource "aws_grafana_workspace" "this" {
+  name                     = "${var.name}-amg"
+  account_access_type      = "CURRENT_ACCOUNT"
+  authentication_providers = ["AWS_SSO"]
+  permission_type          = "SERVICE_MANAGED"
+  role_arn                 = aws_iam_role.amg.arn
+  data_sources             = ["PROMETHEUS"]
+
+  tags = {
+    Component = "amp-amg"
+    Project   = var.name
+  }
+}
+
+# ─── Outputs ─────────────────────────────────────────────────────
+output "amp_workspace_id" {
+  value = aws_prometheus_workspace.this.id
+}
+
+output "amp_remote_write_endpoint" {
+  value = "${aws_prometheus_workspace.this.prometheus_endpoint}api/v1/remote_write"
+}
+
+output "amp_query_endpoint" {
+  value = aws_prometheus_workspace.this.prometheus_endpoint
+}
+
+output "amg_workspace_id" {
+  value = aws_grafana_workspace.this.id
+}
+
+output "amg_endpoint" {
+  value = "https://${aws_grafana_workspace.this.endpoint}"
+}
+
+output "adot_role_arn" {
+  value = aws_iam_role.adot_collector.arn
+}

--- a/components/o11y/amp-amg/values.template.yaml
+++ b/components/o11y/amp-amg/values.template.yaml
@@ -1,0 +1,89 @@
+mode: deployment
+serviceAccount:
+  create: true
+  name: adot-collector
+
+image:
+  repository: public.ecr.aws/aws-observability/aws-otel-collector
+  tag: latest
+
+config:
+  receivers:
+    prometheus:
+      config:
+        global:
+          scrape_interval: 30s
+          evaluation_interval: 30s
+        scrape_configs:
+          # vLLM metrics
+          - job_name: "vllm"
+            kubernetes_sd_configs:
+              - role: pod
+                namespaces:
+                  names: ["vllm"]
+            relabel_configs:
+              - source_labels: [__meta_kubernetes_pod_phase]
+                action: keep
+                regex: Running
+              - source_labels: [__meta_kubernetes_pod_ip]
+                action: replace
+                regex: (.+)
+                replacement: "$$1:8000"
+                target_label: __address__
+              - source_labels: [__meta_kubernetes_pod_name]
+                target_label: pod
+              - source_labels: [__meta_kubernetes_namespace]
+                target_label: namespace
+          # Kubernetes node metrics
+          - job_name: "kubernetes-nodes"
+            scheme: https
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+              - role: node
+            relabel_configs:
+              - action: labelmap
+                regex: __meta_kubernetes_node_label_(.+)
+
+  exporters:
+    prometheusremotewrite:
+      endpoint: "{{AMP_REMOTE_WRITE_ENDPOINT}}"
+      auth:
+        authenticator: sigv4auth
+      resource_to_telemetry_conversion:
+        enabled: true
+
+  extensions:
+    health_check: {}
+    sigv4auth:
+      region: "{{AWS_REGION}}"
+      service: "aps"
+
+  service:
+    extensions: [health_check, sigv4auth]
+    pipelines:
+      metrics:
+        receivers: [prometheus]
+        exporters: [prometheusremotewrite]
+
+resources:
+  limits:
+    cpu: 500m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+
+clusterRole:
+  create: true
+  rules:
+    - apiGroups: [""]
+      resources: ["nodes", "nodes/proxy", "nodes/metrics", "services", "endpoints", "pods"]
+      verbs: ["get", "list", "watch"]
+    - apiGroups: ["extensions", "networking.k8s.io"]
+      resources: ["ingresses"]
+      verbs: ["get", "list", "watch"]
+    - nonResourceURLs: ["/metrics", "/metrics/cadvisor"]
+      verbs: ["get"]


### PR DESCRIPTION
## Summary

Adds a new observability component that provisions Amazon Managed Prometheus (AMP) + Amazon Managed Grafana (AMG) via Terraform and deploys an ADOT collector to remote-write cluster metrics into AMP. Closes the gap where the existing `nvidia-platform/monitoring` was the only Prometheus option (self-hosted kube-prometheus-stack).

This is a re-submission of the AMP/AMG slice from the now-superseded #131 (which conflated several components into one PR per the reviewer feedback to keep the base demo lean).

## What this PR adds

- `components/o11y/amp-amg/index.mjs` — Terraform apply, Helm install of `opentelemetry-collector`, rendered values, status print, uninstall flow.
- `components/o11y/amp-amg/main.tf` — AMP workspace, AMG workspace (`AWS_SSO` auth), IAM roles for ADOT (Pod Identity, `aps:RemoteWrite`) and AMG (assume by `grafana.amazonaws.com`, `aps:QueryMetrics`).
- `components/o11y/amp-amg/values.template.yaml` — ADOT collector configuration with AMP remote-write endpoint and SigV4 auth.
- `cli-menu.json` — Registered under the **Observability** category as `Amazon Managed Prometheus & Grafana (AMP/AMG)`.

## What this PR intentionally does NOT change

- **`./cli demo-setup` is unchanged.** This component is **not** added to `config.json` `demo.components` — installable on demand via `./cli o11y amp-amg install`. This addresses the prior reviewer feedback on #131 about base-demo bloat.
- No changes to the existing `nvidia-platform/monitoring` self-hosted component — the two are complementary (self-hosted for dev, AMP/AMG for prod).

## Architecture

```
Cluster pods (vLLM, LiteLLM, etc.)
    │ (Prometheus scrape)
    ▼
ADOT Collector (k8s, Pod Identity → adot-collector role)
    │ remote_write + SigV4
    ▼
Amazon Managed Prometheus (workspace)
    ▲
    │ aps:QueryMetrics (assumed by grafana.amazonaws.com)
    │
Amazon Managed Grafana (AWS SSO auth, SERVICE_MANAGED data sources)
```

## Test plan

- [ ] `./cli o11y amp-amg install` provisions AMP + AMG via Terraform and deploys ADOT collector
- [ ] ADOT pods reach `Running` in the `opentelemetry` namespace
- [ ] `aws amp list-workspaces` shows the new workspace
- [ ] `aws grafana list-workspaces` shows the new AMG workspace
- [ ] Sample query (e.g. `up`) returns data when AMP is added as a Prometheus data source in Grafana
- [ ] `./cli o11y amp-amg uninstall` cleanly tears everything down (Helm release, namespace, Terraform-managed AWS resources)

## Related

- Closes #123