### PR TITLE
chore: harden .gitignore against accidental credential commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,11 @@ __pycache__/
 # Project
 .DS_Store
 .backup/
+.playwright-mcp/
+
+# Secrets (never commit)
+oidc-credentials.json
+*-credentials.json
 
 # AI Agent Tools
 .kiro/


### PR DESCRIPTION
## Summary

Pure `.gitignore` tightening. No source-code changes.

Adds three patterns that have surfaced in real working trees but must never be committed:

- `oidc-credentials.json` — IAM Identity Center / Cognito OIDC client credential files (clientId + clientSecret) that some component setup flows materialize on disk during install.
- `*-credentials.json` — generic safety net for any future component that serializes credentials to a JSON file.
- `.playwright-mcp/` — local MCP session scratch directory; never useful in commit history.

## Why

A recent local audit on the maintainer side found a real `oidc-credentials.json` (issued by IAM Identity Center, with active `clientSecret`) sitting in an untracked working tree. The credential was rotated/expired by then, but the file was never gitignored, so a `git add -A` from the wrong directory would have committed live credentials.

This is a defense-in-depth change: even if a component is misbehaved and writes a credential JSON next to its code, the file is now ignored by default.

## Test plan

- [x] `git check-ignore components/security/iam-identity-center/oidc-credentials.json` returns the path (matched).
- [x] `git check-ignore .playwright-mcp/test.json` returns the path (matched).
- [x] No previously tracked files become ignored — diff is purely additive.