### PR TITLE
fix: correct terraform set-workspace action name

### DIFF
--- a/cli
+++ b/cli
@@ -329,7 +329,7 @@ async function addTerraformCommands() {
     .description("Manage the infrastructure by using Terraform")
     .addHelpCommand(false);
   const commands = [
-    { name: "set-workspace", description: "Create and select Terraform workspace", action: "setWorkspace" },
+    { name: "set-workspace", description: "Create and select Terraform workspace", action: "setupWorkspace" },
     { name: "plan", description: "Run terraform plan on the selected workspace", action: "plan" },
     { name: "apply", description: "Run terraform apply on the selected workspace", action: "apply" },
     { name: "destroy", description: "Run terraform destroy on the selected workspace", action: "destroy" },


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The `terraform set-workspace` command fails with:

Error running terraform set-workspace: TypeError: utils.terraform[command.action] is not a function

**Root cause:** In `cli`, the `set-workspace` command is mapped with `action: "setWorkspace"`, but the function exported from the `terraform` module in `utils.mjs` is named `setupWorkspace`:

```js
return { setupWorkspace, plan, apply, destroy, output, applyWithRetry };
```

Since utils.terraform.setWorkspace is undefined, calling it throws. The other subcommands (plan, apply, destroy, output) are unaffected because their action names already match.

Fix: Change the action name for set-workspace from setWorkspace to setupWorkspace so it matches the exported function.

**Testing:** Verified after the fix — `./cli terraform set-workspace` now runs successfully:
`terraform init` → `terraform workspace new us-east-1` → `terraform workspace select us-east-1`, and the tfvars workspace directory is created. No more TypeError.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.