### PR TITLE
fix: resolve duplicate OPENAI_API_KEY in Open WebUI values

### DIFF
--- a/components/gui-app/openwebui/values.template.yaml
+++ b/components/gui-app/openwebui/values.template.yaml
@@ -12,10 +12,9 @@ ingress:
 
 # openaiBaseApiUrl: https://litellm.{{{DOMAIN}}}/v1
 openaiBaseApiUrl: http://litellm.litellm:4000/v1
+openaiApiKey: {{{LITELLM_API_KEY}}}
 
 extraEnvVars:
-  - name: OPENAI_API_KEY
-    value: {{{LITELLM_API_KEY}}}
   - name: WEBUI_ADMIN_EMAIL
     value: {{{OPENWEBUI_ADMIN_EMAIL}}}
   - name: WEBUI_ADMIN_PASSWORD


### PR DESCRIPTION
  Open WebUI install failed with:
    duplicate entries for key [name="OPENAI_API_KEY"]

The open-webui chart already injects OPENAI_API_KEY from its openaiApiKey value, but the template also added OPENAI_API_KEY via extraEnvVars, producing two entries and a server-side apply failure.

Use the chart's openaiApiKey field instead of a duplicate extraEnvVars entry.

*Issue #, if available:*

*Description of changes:*
Installing Open WebUI (`./cli gui-app openwebui install`) fails with:

server-side apply failed ... StatefulSet ... .spec.template.spec.containers[name="open-webui"].env: duplicate entries for key [name="OPENAI_API_KEY"]

**Root cause:** The open-webui Helm chart (v12.8.1) already renders an `OPENAI_API_KEY` env var from its `openaiApiKey` value (default `"0p3n-w3bu!"`). `values.template.yaml` additionally defines `OPENAI_API_KEY` under `extraEnvVars`, so the rendered StatefulSet contains two entries with the same name, which Kubernetes server-side apply rejects. The chart's own `values.yaml` comments out the `extraEnvVars` `OPENAI_API_KEY` example and documents `openaiApiKey` as the intended field.

**Fix:** Set the chart's `openaiApiKey` to `LITELLM_API_KEY` and remove the duplicate `OPENAI_API_KEY` entry from `extraEnvVars`.

**Testing:** After the change, `./cli gui-app openwebui install` succeeds (helm upgrade complete, StatefulSet created) and the rendered manifest contains a single `OPENAI_API_KEY` with the LiteLLM key value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
