### PR TITLE
fix: remove Bearer prefix from x-litellm-api-key header in calculator agent

### DIFF
--- a/examples/strands-agents/calculator-agent/agent.py
+++ b/examples/strands-agents/calculator-agent/agent.py
@@ -70,7 +70,7 @@ async def startup_event():
             # Only need one of these 2 headers
             headers = {
                 "Authorization": f"Bearer {os.environ.get("LITELLM_API_KEY")}",
-                "x-litellm-api-key": f"Bearer {os.environ.get("LITELLM_API_KEY")}",
+                "x-litellm-api-key": os.environ.get("LITELLM_API_KEY"),
             }
             mcp_client = MCPClient(
                 lambda: streamablehttp_client(


### PR DESCRIPTION
The MCP gateway call sets both Authorization and x-litellm-api-key headers with a 'Bearer ' prefix. While 'Bearer <key>' is correct for the Authorization header, the x-litellm-api-key header expects the raw key. Sending 'Bearer sk-...' there makes LiteLLM reject the request with 'Malformed API Key passed in. Ensure Key has Bearer prefix', so MCP tool discovery over the gateway (USE_MCP_GATEWAY=true) fails and the agent silently falls back to local tools.

Remove the Bearer prefix from x-litellm-api-key so gateway-based MCP tool calls authenticate correctly.

*Issue #, if available:*

*Description of changes:*
The Strands calculator agent fails to use MCP tools through the LiteLLM gateway (`USE_MCP_GATEWAY=true`). The MCP requests are rejected by LiteLLM with:

Malformed API Key passed in. Ensure Key has Bearer prefix

**Root cause:** In `agent.py`, the gateway MCP client sets two auth headers:

```python
headers = {
    "Authorization": f"Bearer {os.environ.get('LITELLM_API_KEY')}",
    "x-litellm-api-key": f"Bearer {os.environ.get('LITELLM_API_KEY')}",  # wrong
}
```

Bearer <key> is correct for the standard Authorization header, but the LiteLLM-specific x-litellm-api-key header expects the raw key, not a Bearer-prefixed value. LiteLLM parses Bearer sk-... as the whole key and rejects it as malformed. As a result, list_tools_sync() over the gateway fails and the agent silently falls back to local strands_tools, so MCP server tools are never actually exercised via the gateway.

Fix: Send the raw key in x-litellm-api-key (drop the Bearer  prefix).
The Authorization header is left unchanged.

Testing: Root cause was confirmed by observing the failing request in Langfuse traces (litellm-/mcp/ spans with the "Malformed API Key" error) and inspecting the header code in the running pod. I have not built and deployed a new container image to verify end-to-end, since the agent uses a pre-built public ECR image and rebuilding/publishing is outside my setup. The change is a one-line header-format correction consistent with LiteLLM's documented x-litellm-api-key usage; maintainers with the image build pipeline can validate the full flow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
