### PR TITLE
fix: use single Authorization header for MCP gateway auth in calculator agent

### DIFF
--- a/examples/strands-agents/calculator-agent/agent.py
+++ b/examples/strands-agents/calculator-agent/agent.py
@@ -67,10 +67,11 @@ async def startup_event():
         print("Using MCP tools...")
         if os.environ.get("USE_MCP_GATEWAY", "").lower() == "true":
             print(f"Using MCP gateway...")
-            # Only need one of these 2 headers
+            # LiteLLM's /mcp route requires the "Bearer " prefix even in
+            # x-litellm-api-key, so a single standard Authorization header
+            # is sufficient and avoids sending the key twice
             headers = {
                 "Authorization": f"Bearer {os.environ.get("LITELLM_API_KEY")}",
-                "x-litellm-api-key": os.environ.get("LITELLM_API_KEY"),
             }
             mcp_client = MCPClient(
                 lambda: streamablehttp_client(


### PR DESCRIPTION
*Issue #, if available:* Follow-up to #170

*Description of changes:*

## Problem

#170 removed the `Bearer ` prefix from the `x-litellm-api-key` header on the assumption that this header expects a raw key. That is true for regular LLM routes (`/v1/chat/completions` etc.), which go through FastAPI dependency injection and the lenient parser (`_get_bearer_token_or_received_api_key`) that accepts both formats.

However, the `/mcp` route is different. The MCP auth handler (`litellm/proxy/_experimental/mcp_server/auth/user_api_key_auth_mcp.py`) extracts the header value verbatim and calls `user_api_key_auth(api_key=<value>, request=request)` directly, which routes it through the **strict** parser (`_get_bearer_token`): any value without a `Bearer `/`bearer `/`Basic ` prefix is zeroed to `""` and rejected with:

```
Malformed API Key passed in. Ensure Key has `Bearer ` prefix.
```

Since `x-litellm-api-key` takes precedence over `Authorization` when both are present, sending it as a raw key breaks MCP gateway auth even though the `Authorization` header is still correct — reproducing exactly the symptom #170 set out to fix (gateway tool discovery fails, agent silently falls back to local tools).

This behavior is consistent from LiteLLM v1.72 (when MCP auth was introduced) through current main, and the official MCP docs show `x-litellm-api-key: Bearer sk-1234` (with prefix): https://docs.litellm.ai/docs/mcp

## Fix

Drop `x-litellm-api-key` entirely and keep only the standard `Authorization: Bearer` header (the existing comment already noted only one of the two is needed). This fixes gateway auth and avoids sending the same credential in two headers.

## Testing

Verified empirically against `ghcr.io/berriai/litellm:main-v1.81.3-stable` — the exact tag pinned in `components/ai-gateway/litellm/values.template.yaml` — by sending MCP `initialize` requests to `/mcp/`:

| Headers sent | Result |
|---|---|
| `Authorization: Bearer <key>` only (**this PR**) | HTTP 200, valid MCP initialize response |
| `x-litellm-api-key: Bearer <key>` + `Authorization: Bearer <key>` (pre-#170) | HTTP 200 |
| `x-litellm-api-key: <raw key>` + `Authorization: Bearer <key>` (current main, post-#170) | HTTP 500, "Malformed API Key" in proxy logs |
| `x-litellm-api-key: Bearer <key>` only | HTTP 200 |
| wrong key (sanity check) | HTTP 500 |

Note on deployment impact: the currently published `public.ecr.aws/agentic-ai-platforms-on-k8s/strands-agents-calculator-agent:latest` image (built 2026-06-20) still contains the pre-#170 code, so nothing is broken in deployments today — but the next image rebuild from main would ship the regression. This PR should land before any rebuild.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.