### PR TITLE
fix(docs): add FAQ and Security pages to Reference nav

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -148,3 +148,5 @@ nav:
   - Reference:
     - CLI Commands: reference/cli-commands.md
     - Configuration: reference/configuration.md
+    - FAQ: reference/faq.md
+    - Security: reference/security.md


### PR DESCRIPTION
*Description of changes:*

`docs/reference/faq.md` and `docs/reference/security.md` are built and published but are missing from the site navigation — the `Reference:` section of `mkdocs.yml` lists only two of the four pages in `docs/reference/`.

Both were present when the docs site landed in #121. They appear to have been dropped incidentally in #161 ("Change Flexible AI default landing page language to English"), whose entire `mkdocs.yml` diff is the two Flexible AI landing renames plus:

```diff
-    - FAQ: reference/faq.md
-    - Security: reference/security.md
```

This restores them.

**Testing**

Rendered with `mkdocs serve`. `mkdocs build --strict` exits 0 with zero warnings before and after — run with the `social` plugin disabled locally, since its imaging dependencies would not install on my machine; that plugin does not read `nav`.

AS-IS — `FAQ` and `Security` are absent from the Reference nav:

![as-is](https://raw.githubusercontent.com/bell-hyun/sample-genai-on-eks-starter-kit/88b8d5baeb89417cabcc5fc0782b489bfcd75736/as-is.png)

TO-BE — both appear under Reference:

![to-be](https://raw.githubusercontent.com/bell-hyun/sample-genai-on-eks-starter-kit/88b8d5baeb89417cabcc5fc0782b489bfcd75736/to-be.png)

`mkdocs.yml` only, 2 lines added.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
