### PR TITLE
fix(flexible-ai): remove duplicated OFFERINGS section from Korean lan…

### DIFF
--- a/docs/flexible-ai/landing.ko.html
+++ b/docs/flexible-ai/landing.ko.html
@@ -942,22 +942,7 @@ FLEXIBLE AI · AWS
 </div>
 
 </section>
-<section id="offerings">
-<div class="reveal">
-<div class="section-label">OFFERINGS</div>
-<h2 class="section-title">Offerings</h2>
-<p class="section-desc">아키텍처를 처음부터 구축하는 환경부터 기존에 구축된 환경을 고도화하는 것까지,<br>모든 단계에 맞춘 아키텍처와 지원 체계, 스타터 킷을 제공합니다.</p>
-</div>
-<div class="offering-grid">
-<div class="offering-card reveal"><div class="offering-icon">🏗️</div><h3>Full-stack AI Baseline</h3><ul><li>사전 검증된 레퍼런스 아키텍처</li><li>유연·확장 가능한 디자인 패턴</li><li>통합 셀프 서비스 포털</li></ul></div>
-<div class="offering-card reveal"><div class="offering-icon">🤝</div><h3>White-glove Support</h3><ul><li>AWS Specialist 기술 가이던스</li><li>GPU 가치 극대화 베스트 프랙티스</li><li>글로벌 배포 지원</li></ul></div>
-<div class="offering-card reveal"><div class="offering-icon">🛍️</div><h3>Marketplace Solutions</h3><ul><li>OSS 사전 구성 스택</li><li>1-Click Launch 최적화 AMI</li><li>Enterprise Edition 옵션</li></ul></div>
-<div class="offering-card reveal"><div class="offering-icon">🚀</div><h3>Starter Kit</h3><ul><li>GenAI 인프라 통합 툴킷</li><li>E2E Observability 기본 포함</li></ul></div>
-</div>
-
-
 <!-- 8. OFFERINGS -->
-</section>
 <section id="offerings">
 <div class="reveal">
 <div class="section-label">OFFERINGS</div>


### PR DESCRIPTION
## Summary

`docs/flexible-ai/landing.ko.html` renders the OFFERINGS section twice. This PR
removes the duplicated block.

## Problem

The `<section id="offerings">` block appears twice, repeated verbatim — same
heading, same description, same four offering cards. Two consequences:

- The page shows 8 offering cards instead of 4
- `id="offerings"` is duplicated, which is invalid HTML and breaks the
  `#offerings` anchor used by the nav

The English `docs/flexible-ai/landing.html` contains the section only once,
which confirms the duplication is accidental rather than intentional.

## Before / After
#### Before (duplicated)
<img width="1440" height="1400" alt="before-offerings" src="https://github.com/user-attachments/assets/1769a7e3-aeeb-43f2-9897-ac874181b88c" /> 

#### After
<img width="1512" height="778" alt="after-offerings" src="https://github.com/user-attachments/assets/e98d012f-8cd3-4b19-aaeb-e592c916d966" /> 

## Verification

```bash
grep -c '<section id="offerings">' docs/flexible-ai/landing.ko.html   # 1 (was 2)
grep -c 'offering-card'            docs/flexible-ai/landing.ko.html   # 4 (was 8)
grep -o 'id="[^"]*"' docs/flexible-ai/landing.ko.html | sort | uniq -d  # no output

Notes

- Deletion only; no content or styling changes.
- No reformatting, per the CONTRIBUTING.md guidance to keep the diff focused —
  prettier --check reports pre-existing style warnings across the repo that
  are intentionally left untouched.