### PR TITLE
fix(vllm-ray): pin image + right-size worker for reliable Ray autoscale (e2e findings)

### DIFF
--- a/components/llm-model/vllm-ray/rayservice-qwen3-8b-neuron.yaml
+++ b/components/llm-model/vllm-ray/rayservice-qwen3-8b-neuron.yaml
@@ -24,8 +24,8 @@ spec:
             kubernetes.io/arch: amd64
           containers:
           - name: ray-head
-            image: public.ecr.aws/agentic-ai-platforms-on-k8s/ray-vllm-neuron:latest
-            imagePullPolicy: Always
+            image: public.ecr.aws/agentic-ai-platforms-on-k8s/ray-vllm-neuron:sha-b66faee
+            imagePullPolicy: IfNotPresent
             command: ["/bin/bash","-lc"]
             args:
             - |
@@ -85,8 +85,8 @@ spec:
           - { key: "aws.amazon.com/neuron", operator: "Exists", effect: "NoSchedule" }
           containers:
           - name: ray-worker
-            image: public.ecr.aws/agentic-ai-platforms-on-k8s/ray-vllm-neuron:latest
-            imagePullPolicy: Always
+            image: public.ecr.aws/agentic-ai-platforms-on-k8s/ray-vllm-neuron:sha-b66faee
+            imagePullPolicy: IfNotPresent
             command: ["/bin/bash","-lc"]
             args:
             - |
@@ -99,7 +99,11 @@ spec:
             - { name: HF_HUB_CACHE, value: "/root/.cache/huggingface/hub" }
             resources:
               requests: { cpu: 3, memory: 12Gi, aws.amazon.com/neuroncore: 2 }
-              limits: { memory: 20Gi, aws.amazon.com/neuroncore: 2 }
+              # inf2.xlarge has 16 GiB total (allocatable is lower after system reservation),
+              # and the shm emptyDir below (medium: Memory) also counts toward pod memory, so a
+              # 20Gi limit could not fit / was OOM-fragile. Right-sized to 12Gi to match the request
+              # and fit the node. NOTE: validate under sustained load before merging to main.
+              limits: { memory: 12Gi, aws.amazon.com/neuroncore: 2 }
             livenessProbe:
               exec:
                 command: ["bash","-c","python3 -c \"import urllib.request,sys; sys.exit(0 if b'success' in urllib.request.urlopen('http://localhost:52365/api/local_raylet_healthz',timeout=8).read() else 1)\""]


### PR DESCRIPTION
## Steps taken

This change came out of a faithful, end-to-end participant run of the "Build and operate agentic AI platforms on Amazon EKS" workshop, exercising the Ray autoscaling lab (Track A) and inspecting Track B.

1. Built a validation branch equal to the Ray component PR plus a one-line foundation config fix (switch the foundation model to the inf2 neuron variant so the neuron NodePool is exercised).
2. Published the Ray serving image to the public ECR repo and pinned it by digest tag: `public.ecr.aws/agentic-ai-platforms-on-k8s/ray-vllm-neuron:sha-b66faee`.
3. Created a workshop-content branch that repoints the starter-kit clone to this validation branch.
4. Provisioned a live test event in us-west-2 (EKS Auto Mode cluster with a dedicated neuron NodePool).
5. Ran BOTH tracks verbatim as a participant, from the workshop's in-browser Code Editor.
6. Followed up with a 7-lens adversarial verification pass (6 static + 1 live) to refute or confirm each finding before reporting it.

## Findings

Grouped by attribution. Only the two Ray-component defects (M1, M2) are code-fixed in this PR; everything else is documented as a follow-up.

### (a) Ray-lab defects attributable to the Ray component

- **M1 (fixed here) — root cause of the incomplete autoscale.** The RayService used image tag `:latest` with `imagePullPolicy: Always` on an ~18GB image. Every autoscaled worker re-pulled the full image (~10 min) before it could serve. Under the lab's load test, scale-up did trigger and Karpenter provisioned a fresh inf2 node, but the second worker was still pulling when load subsided and **never reached a serving state** — so the "1 -> 2 workers serving" outcome was never actually demonstrated. Fix: pin `:sha-b66faee` and set `imagePullPolicy: IfNotPresent` (applied to both head and worker for reproducibility).
- **M2 (fixed here).** The worker memory limit was `20Gi`, but `inf2.xlarge` has only 16 GiB total (allocatable is lower after system reservation), and the `shm` emptyDir (`medium: Memory`) also counts toward pod memory — making the pod OOM-fragile. Right-sized the limit to `12Gi` (matching the request). This should be validated under sustained load before merging to main.
- **Partial autoscale / second worker never served (documented, root-caused by M1 above).**
- **LiteLLM `config.yaml` live-patch crash in the Part-5 step (NOT fixed here — content-side).** The lab step appends a `- litellm_params:` list item to the live LiteLLM `config.yaml` via a `cat >>` heredoc. This produces invalid YAML: `model_list` is not the final block in the file, and the appended item lands at column 0 under a mapping root, so the config fails to parse and a restarted gateway replica crash-loops. This lives in the workshop content repo, not in this component; it needs a structured (e.g. `yq`) insertion rather than a raw append. Flagged to the content owner as a follow-up.

### (b) Pre-existing workshop bugs (not related to this component)

- **module4 and module5 assets are absent from the starter kit.** The monitoring lab (module4) and the RAG / streaming labs (module5) `cd` into directories that do not exist in the kit on any branch/tag, so those sections cannot be completed as written. The assets currently live only in the workshop content repo and are never synced into the participant-side clone.
- **`kubectl get ec2nodeclass` fails on Auto Mode.** The cluster is EKS Auto Mode, whose NodeClasses are `nodeclasses.eks.amazonaws.com` (the `ec2nodeclasses.karpenter.sh` CRD is absent). The guide instructs `kubectl get ec2nodeclass`, which errors live.
- **Model-routing step greps a non-existent path.** The step points at an app path under a directory that does not exist; the real source lives under the module3 static-code path.

### (c) Track B (INSPECTION-ONLY — not live-reproduced; this component touches zero Track B files)

- **RAG MCP server URLs swapped (blocker).** In the module5 RAG pipeline agent, two MCP server URLs are transposed, so the agent routes tool calls to the wrong servers.
- Two additional HIGH-severity issues in Track B: a model-id contradiction between two steps that breaks exact-match cost attribution, and a step-ordering issue where the enhanced RAG tool is exercised before it is redeployed into the agent (so the un-enhanced agent is what gets tested).

### (d) Region-portability note (downgraded)

A previously feared blocker — a Kong -> Bedrock cascade failure from an `us-east-1` role lookup — was investigated and **refuted** both statically and live: the role lookup is region-parameterized and resolves the correct `us-west-2` role. The only real residual is a set of scoped literal `us-east-1` hardcodes in later Track B modules (app manifest, monitoring export, a boto3 client, and a judge region), which is a portability nit, not a blocker.
