### PR TITLE
workshops: revert Qwen3-8B foundation model from trn1 back to inf2

### DIFF
--- a/workshops/eks-genai-workshop/config.workshop.json
+++ b/workshops/eks-genai-workshop/config.workshop.json
@@ -11,7 +11,7 @@
   "llm-model": {
     "vllm": {
       "models": [
-        { "name": "qwen3-8b-neuron-trn1", "deploy": true, "neuron": true, "compile": false },
+        { "name": "qwen3-8b-neuron", "deploy": true, "neuron": true, "compile": false },
         { "name": "deepseek-r1-qwen3-8b-neuron", "deploy": true, "neuron": true, "compile": false }
       ]
     },


### PR DESCRIPTION
## What

One-line revert in `workshops/eks-genai-workshop/config.workshop.json`: switch the Qwen3-8B foundation model from `qwen3-8b-neuron-trn1` (trn1.2xlarge) back to `qwen3-8b-neuron` (inf2.xlarge), the prior known-good default.

## Why

The trn1 pin leaves the foundation-model pod Pending in live workshop events that lack trn1 capacity. inf2 was the working default before the split to trn1. Reverting unblocks the current event.

## Scope

- Single line, single file. No template, NodePool, or terraform changes needed: the neuron Karpenter NodePool already permits the inf2 family, and `model-qwen3-8b-neuron.template.yaml` (inf2.xlarge, neuroncore: 2, TP=2, max-model-len 8192) is present and correctly sized for inf2.xlarge.
- Independent of PR #190 (Ray, WIP) and Track B. This is the dedicated qwen inf2 revert; basis for release v1.1.3.

## Verification

- inf2 present in neuron NodePool instance-family list; template resource requests fit inf2.xlarge exactly (no over-request, no OOM risk at load).
- Secondary model `deepseek-r1-qwen3-8b-neuron` unchanged, shares the same schedulable inf2 path.
- Orphaned `-trn1` template left in place (inert; no config references it after this change).