### PR TITLE
fix(docs): correct eight spelling errors across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,13 +240,13 @@ This command will:
 
 ### How the config files work?
 
-`.env` and `config.json` will be loaded first. Then, the configs will be merged/overriden with the values from `.env.local` and `config.local.json` if exist.
+`.env` and `config.json` will be loaded first. Then, the configs will be merged/overridden with the values from `.env.local` and `config.local.json` if exist.
 
 ### How can I use this starter kit without having a Route 53 hosted zone?
 
 With a domain name already configured with a Route 53 hosted zone, a single shared ALB with HTTPS is used together with a wildcard ACM cert and Route 53 DNS records to expose all public facing services e.g. litellm.<DOMAIN> and openwebui.<DOMAIN>.
 
-Alternatively, when the `DOMAIN` filed on `.env` (or `.env.local`) is empty, mulitple ALBs with HTTP will be created for each public facing service. In this case, only one service requiring the Nginx Ingress basic auth (e.g. Milvus and Qdrant) can be exposed.
+Alternatively, when the `DOMAIN` field on `.env` (or `.env.local`) is empty, multiple ALBs with HTTP will be created for each public facing service. In this case, only one service requiring the Nginx Ingress basic auth (e.g. Milvus and Qdrant) can be exposed.
 
 ### How can I configure and update the LiteLLM proxy model list?
 

--- a/components/ai-gateway/kong/KONG.md
+++ b/components/ai-gateway/kong/KONG.md
@@ -4,7 +4,7 @@ Currently, we only deploy Kong and setup the API key but we do not setup the rou
 
 Notes:
 
-- [AI Proxy plugin](https://developer.konghq.com/plugins/ai-proxy) currently does not provide the simple way to setup mulitple models on the same URL path. See `components/ai-gateway/kong/examples/kong.yaml` as example to set a route for each model.
+- [AI Proxy plugin](https://developer.konghq.com/plugins/ai-proxy) currently does not provide the simple way to setup multiple models on the same URL path. See `components/ai-gateway/kong/examples/kong.yaml` as example to set a route for each model.
 
 - Alternatively, check [this example](https://developer.konghq.com/plugins/ai-proxy/examples/sdk-two-routes/) for setting up the AI proxy plugin routing based on matching different URL paths.
 

--- a/components/guardrail/guardrails-ai/docker/Dockerfile
+++ b/components/guardrail/guardrails-ai/docker/Dockerfile
@@ -28,7 +28,7 @@ ENV NLTK_DATA=/opt/nltk_data
 RUN python -m nltk.downloader -d /opt/nltk_data punkt
 
 # Copy the rest over (including entrypoint script)
-# We use a .dockerignore to keep unwanted files exluded
+# We use a .dockerignore to keep unwanted files excluded
 COPY . .
 
 # Make entrypoint script executable

--- a/docs/DEMO_WALKTHROUGH.md
+++ b/docs/DEMO_WALKTHROUGH.md
@@ -33,7 +33,7 @@ Access Open WebUI at `openwebui.<DOMAIN>` and then:
    - Check [Chat Features Overview](https://docs.openwebui.com/features/chat-features) on how to start using the chat features
 
    - Check [Tutorial: Configuring RAG with Open WebUI Documentation](https://docs.openwebui.com/tutorials/tips/rag-tutorial) on how to start using the document RAG feature
-   - Select and explore `Strands Agents - Calculator Agent` (code available at `examples/strands-agents/calculator-agent`), this is a basic agent with memory so you can continue the calculation and/or reset the caculator
+   - Select and explore `Strands Agents - Calculator Agent` (code available at `examples/strands-agents/calculator-agent`), this is a basic agent with memory so you can continue the calculation and/or reset the calculator
 
 2. Access LiteLLM dashboard at `litellm.<DOMAIN>/ui` (check `LITELLM_UI_USERNAME` and `LITELLM_UI_PASSWORD` on `.env.local` for Username and Password):
    - Check [LiteLLM Proxy Server (LLM Gateway)](https://docs.litellm.ai/docs/simple_proxy) to explore some of the features

--- a/docs/INFRA_SETUP.md
+++ b/docs/INFRA_SETUP.md
@@ -11,9 +11,9 @@ Several AWS services and Kubernetes components are being provisioned by the main
 - One VPC with private/public subnets and single NAT gateway
 - One EKS Auto Mode cluster
 - One EFS file system for caching Hugging Face models and etc
-- One ACM wildcard certificate for the provided domin
+- One ACM wildcard certificate for the provided domain
 
-### Kubenertes Components
+### Kubernetes Components
 
 - Setup Ingress to provision the shared ALB
 - Setup ExternalDNS to manage the DNS records for the public facing services


### PR DESCRIPTION
## Summary

Eight spelling errors across five files (seven lines). Three are on the published site. Spelling
only — no wording, structure, or formatting changes.

## Problem

| % | File:line | Current | Corrected | On the site |
|---|---|---|---|---|
| 1 | `README.md:243` | `merged/overriden` | `merged/overridden` | no |
| 2 | `README.md:249` | `` the `DOMAIN` filed on `` | `` the `DOMAIN` field on `` | no |
| 3 | `README.md:249` | `mulitple ALBs` | `multiple ALBs` | no |
| 4 | `components/ai-gateway/kong/KONG.md:7` | `setup mulitple models` | `setup multiple models` | no |
| 5 | `components/guardrail/guardrails-ai/docker/Dockerfile:31` | `files exluded` | `files excluded` | no |
| 6 | `docs/DEMO_WALKTHROUGH.md:36` | `reset the caculator` | `reset the calculator` | **yes** — `/DEMO_WALKTHROUGH/` |
| 7 | `docs/INFRA_SETUP.md:14` | `the provided domin` | `the provided domain` | **yes** — `/INFRA_SETUP/` |
| 8 | `docs/INFRA_SETUP.md:16` | `### Kubenertes Components` | `### Kubernetes Components` | **yes** — `/INFRA_SETUP/` |

%5 is a comment inside a Dockerfile, not a documentation page. It is included because it is the same
class of defect and the one-word fix carries no build risk.

%2 is worth calling out because it is not a misspelling a dictionary can catch — `filed` is a real
word. It is confirmed a typo by the repo's own copy of the same sentence: `docs/overrides/main.html:147`
already renders it as `"When the DOMAIN field in .env is empty…"` in the site's structured data.

`codespell` found the other seven; all line numbers above were re-checked with `grep -n`.

## Site impact

| Page | Fixes |
|---|---|
| `/DEMO_WALKTHROUGH/` | 1 (`caculator`) |
| `/INFRA_SETUP/` | 2 (`domin`, `Kubenertes`) |

`README.md`, `KONG.md` and the Dockerfile are not part of the docs site. `README.md` is included
because it is the repo's front door, and `mulitple` appears in both it and `KONG.md`.

%8 changes a heading, so its anchor changes from `#kubenertes-components` to
`#kubernetes-components`. Nothing links to the old anchor:

```bash
grep -rn 'kubenertes-components' .    # no matches
```

## Verification

Both affected site pages were built locally and compared before and after.

**`/INFRA_SETUP/`** — `domin` → `domain`, and `Kubenertes` → `Kubernetes` in both the heading and
the table of contents:

<img width="1400" height="1089" alt="infra-setup" src="https://github.com/user-attachments/assets/21c2c4ae-b3ed-4765-9f62-9afc97442a30" />


**`/DEMO_WALKTHROUGH/`** — `caculator` → `calculator`:


<img width="1400" height="772" alt="demo-walkthrough" src="https://github.com/user-attachments/assets/23eebc38-9b65-4926-a8fd-179637d141a0" />


<details>
<summary>Command output</summary>

```console
$ git rev-parse --short HEAD
94c73e1

$ python3 -m codespell_lib --skip='./node_modules,./.git,./package-lock.json,./.idea,*.svg,*.png,*.lock' .
./README.md:243: overriden ==> overridden
./README.md:249: mulitple ==> multiple
./docs/DEMO_WALKTHROUGH.md:36: caculator ==> calculator
./docs/INFRA_SETUP.md:14: domin ==> doming, domain, domino
./docs/INFRA_SETUP.md:16: Kubenertes ==> Kubernetes
./components/ai-gateway/kong/KONG.md:7: mulitple ==> multiple
./components/guardrail/guardrails-ai/docker/Dockerfile:31: exluded ==> excluded, exuded
$ echo $?
65

# --- apply this PR ---

$ python3 -m codespell_lib --skip='./node_modules,./.git,./package-lock.json,./.idea,*.svg,*.png,*.lock' .
$ echo $?
0

$ mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Building documentation to directory: /tmp/site
INFO    -  The following pages exist in the docs directory, but are not included in the "nav" configuration:
  - DEMO_WALKTHROUGH.md
  - INFRA_SETUP.md
  - SECURITY.md
INFO    -  Documentation built in 1.18 seconds
$ echo $?
0

$ git diff --stat 94c73e1
 README.md                                            | 4 ++--
 components/ai-gateway/kong/KONG.md                   | 2 +-
 components/guardrail/guardrails-ai/docker/Dockerfile | 2 +-
 docs/DEMO_WALKTHROUGH.md                             | 2 +-
 docs/INFRA_SETUP.md                                  | 4 ++--
 5 files changed, 7 insertions(+), 7 deletions(-)
```

</details>

`codespell` 2.4.3; `mkdocs` 1.6.1 installed from `docs/requirements.txt` in a clean venv.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this
contribution, under the terms of your choice.