### PR TITLE
fix: Correct Guardrails AI multi-architecture nodeSelector condition

### DIFF
--- a/components/guardrail/guardrails-ai/index.mjs
+++ b/components/guardrail/guardrails-ai/index.mjs
@@ -31,8 +31,9 @@ export async function install() {
   
   const appTemplatePath = path.join(DIR, "app.template.yaml");
   const appRenderedPath = path.join(DIR, "app.rendered.yaml");
-  const { arch } = config.docker;
+  const { useBuildx, arch } = config.docker;
   const appVars = {
+    useBuildx,
     arch,
     IMAGE: publicEcrImage,
     GUARDRAILS_TOKEN: GUARDRAILS_AI_API_KEY,


### PR DESCRIPTION
## Why was this a problem?

The Guardrails AI deployment template is intended to add a kubernetes.io/arch nodeSelector only when useBuildx is false.

However, the install code did not pass useBuildx to the template. As a result, the missing value was treated as false, and the nodeSelector was always rendered—even with
the default multi-architecture setting (useBuildx: true). This could restrict Guardrails AI Pods to arm64 nodes.

## How was it fixed?

The install code now reads useBuildx from config.docker and passes it to the template rendering variables.

With multi-architecture enabled, no architecture-specific nodeSelector is rendered. With single-architecture builds, the configured arch value is still used to create the
nodeSelector.