### PR TITLE
docs: fix Terraform variables path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ For Bedrock models, the model list hardcoded on config.json.
 
 ### How can I change the EC2 GPU instance families and purchasing options?
 
-The default instance families are g6e, g6 and g5g and the default purchasing options are spot and on-demand. You can change the values on `terraform/0-common.tf` and then run `./cli terraform apply again`.
+The default instance families are g6e, g6 and g5g and the default purchasing options are spot and on-demand. You can change the values on `terraform/variables.tf` and then run `./cli terraform apply again`.
 
 Note that the model deployment manifests use `nodeSelector` like `eks.amazonaws.com/instance-family: g6e` to lock the specific tested instance family which you will need to adjust accordingly.
 


### PR DESCRIPTION
*Issue #184*

*Description of changes:*

Updated the outdated Terraform file reference in the README from `terraform/0-common.tf` to `terraform/variables.tf`.

The GPU node pool configuration variables are currently defined in `terraform/variables.tf`.