### PR TITLE
fix: resolve ReferenceError on models and remove non-existent neuron pvc in TGI

### DIFF
--- a/components/llm-model/tgi/index.mjs
+++ b/components/llm-model/tgi/index.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 import path from "path";
 import fs from "fs";
 import handlebars from "handlebars";
-import { $, cd } from "zx";
+import { $ } from "zx";
 $.verbose = true;
 
 export const name = "TGI";
@@ -26,7 +26,6 @@ export async function install() {
 
   await $`kubectl apply -f ${path.join(DIR, "namespace.yaml")}`;
   await $`kubectl apply -f ${path.join(DIR, "pvc-huggingface-cache.yaml")}`;
-  await $`kubectl apply -f ${path.join(DIR, "pvc-neuron-cache.yaml")}`;
   const secretTemplatePath = path.join(DIR, "secret.template.yaml");
   const secretRenderedPath = path.join(DIR, "secret.rendered.yaml");
   const secretTemplateString = fs.readFileSync(secretTemplatePath, "utf8");
@@ -36,6 +35,7 @@ export async function install() {
   };
   fs.writeFileSync(secretRenderedPath, secretTemplate(secretVars));
   await $`kubectl apply -f ${secretRenderedPath}`;
+  const { models } = config["llm-model"]["tgi"];
   await utils.model.addModels(models, "llm-model", "tgi");
 }
 
@@ -44,6 +44,5 @@ export async function uninstall() {
   await utils.model.removeAllModels(models, "llm-model", "tgi");
   await $`kubectl delete -f ${path.join(DIR, "secret.rendered.yaml")} --ignore-not-found`;
   await $`kubectl delete -f ${path.join(DIR, "pvc-huggingface-cache.yaml")} --ignore-not-found`;
-  await $`kubectl delete -f ${path.join(DIR, "pvc-neuron-cache.yaml")} --ignore-not-found`;
   await $`kubectl delete -f ${path.join(DIR, "namespace.yaml")} --ignore-not-found`;
 }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Running `./cli llm-model tgi install` fails with two runtime errors:

1. `ReferenceError: models is not defined`
2. `error: the path ".../components/llm-model/tgi/pvc-neuron-cache.yaml" does not exist`

**Root cause:**
- In `components/llm-model/tgi/index.mjs`, `install()` calls `await utils.model.addModels(models, "llm-model", "tgi");`, but `models` was not destructured from `config` (unlike `uninstall()`, which has `const { models } = config["llm-model"]["tgi"];`).
- `install()` and `uninstall()` attempt to apply and delete `pvc-neuron-cache.yaml`, but this file does not exist in `components/llm-model/tgi/` (it only exists under `vllm`).
- `cd` is imported from `zx` but unused.

**Fix:**
- Destructure `models` from `config["llm-model"]["tgi"]`.
- Remove references to `pvc-neuron-cache.yaml` from both `install()` and `uninstall()`.
- Clean up unused `cd` import.

**Testing:**
- Ran `node --check components/llm-model/tgi/index.mjs` and `npx prettier --check components/llm-model/tgi/index.mjs`.
- Verified `./cli llm-model tgi --help` runs without module load errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.