### PR TITLE
fix(milvus): add missing helm repo and fallback to REGION env var

### DIFF
--- a/components/vector-database/milvus/index.mjs
+++ b/components/vector-database/milvus/index.mjs
@@ -26,6 +26,9 @@ export async function install() {
   const tfOutput = await utils.terraform.output(DIR, {});
   const milvusBucketName = tfOutput.milvus_bucket_name.value;
 
+  await $`helm repo add milvus https://zilliztech.github.io/milvus-helm`;
+  await $`helm repo update`;
+
   const valuesTemplatePath = path.join(DIR, "values.template.yaml");
   const valuesRenderedPath = path.join(DIR, "values.rendered.yaml");
   const valuesTemplateString = fs.readFileSync(valuesTemplatePath, "utf8");
@@ -33,7 +36,7 @@ export async function install() {
   const valuesVars = {
     DOMAIN: process.env.DOMAIN,
     MILVUS_BUCKET_NAME: milvusBucketName,
-    AWS_REGION: process.env.AWS_REGION,
+    AWS_REGION: process.env.AWS_REGION || process.env.REGION,
   };
   fs.writeFileSync(valuesRenderedPath, valuesTemplate(valuesVars));
   await $`helm upgrade --install milvus milvus/milvus --namespace milvus --create-namespace -f ${valuesRenderedPath}`;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Add missing Helm repository registration for Milvus and add fallback to REGION environment variable.

1. In components/vector-database/milvus/index.mjs, running install failed on environments where the milvus Helm repo was not pre-registered. Added "helm repo add" and "helm repo update" before running helm upgrade.
2. Fallback to process.env.REGION when process.env.AWS_REGION is undefined, ensuring S3 endpoint resolution works with standard .env settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
