### PR TITLE
ci: add codespell spell-check on pull requests

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,10 @@
+# codespell configuration (https://github.com/codespell-project/codespell).
+# CI runs `codespell` with no arguments from the repository root, so it reads
+# these settings; running `codespell` locally reproduces the check exactly.
+[codespell]
+skip = ./site,./node_modules,./package-lock.json,*.lock,*.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.woff,*.woff2,*.pdf
+# Domain terms codespell should not report, comma-separated and lowercase.
+# Seeded with the product names called out in #201; none of them is in the
+# current dictionaries, so add new entries only when a term is actually
+# reported, and keep them specific — an entry silences that word repo-wide.
+ignore-words-list = karpenter,langfuse,vllm,neuron

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+name: Spell Check
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install codespell
+        run: pip install codespell==2.4.3
+
+      - name: Run codespell
+        run: codespell


### PR DESCRIPTION
*Issue #201*

## Summary

Adds a `codespell` check that runs on every pull request, as proposed in #201. Two new files —
`.github/workflows/codespell.yml` and `.codespellrc` — and nothing existing touched. `codespell`
reports nothing on `main` at `7cafc97`, so the check starts green.

## Problem

Spelling is not checked anywhere today, and no workflow runs on pull requests at all — `docs.yml`
triggers on `push` to `main` behind a `docs/**` path filter. #196 fixed 8 typos across 5 files, and
5 of them sit outside that filter (`README.md` ×3, `KONG.md`, a Dockerfile comment), so even that
workflow would never have seen them.

At `94c73e1`, the commit before #196:

```console
$ codespell
./README.md:243: overriden ==> overridden
./README.md:249: mulitple ==> multiple
./docs/DEMO_WALKTHROUGH.md:36: caculator ==> calculator
./docs/INFRA_SETUP.md:14: domin ==> doming, domain, domino
./docs/INFRA_SETUP.md:16: Kubenertes ==> Kubernetes
./components/ai-gateway/kong/KONG.md:7: mulitple ==> multiple
./components/guardrail/guardrails-ai/docker/Dockerfile:31: exluded ==> excluded, exuded
```

7 of the 8. The eighth was `the DOMAIN filed on`, where `filed` is a real word — this closes most
of that class, not all of it.

## Configuration

| Setting | Value | Why |
|---|---|---|
| On a hit | **blocking** — the job fails, no `continue-on-error` | The tree is clean at `7cafc97`, so it starts green and cannot land red on unrelated work, and false positives measure 0 across the 358 tracked files. A red run still only gates the merge button once the check is added to branch protection |
| Local hook | **none — CI only** | Nothing in the repo to extend (no `.pre-commit-config.yaml`, `pyproject.toml` or `husky`), and a hook is skippable with `--no-verify`. The settings sit in `.codespellrc`, so the local equivalent is already one command |
| Dictionaries | default (`clear`, `rare`) | `--builtin clear,rare,informal,usage,code,names` reports 81 findings here, all false: `ws` 43 (the WebSocket import under `examples/openclaw/shared/`), `IAM`/`iam` 28, `master` 6, `warmup` 3, `Lite` 1 |
| `ignore-words-list` | `karpenter,langfuse,vllm,neuron` | The four names #201 called out, seeded so the key is in place. None of them is a dictionary entry today, so the list changes nothing yet — it is a location for future entries, not a silencer |
| `skip` | `site/`, `node_modules/`, `package-lock.json`, `*.lock`, image and font binaries | The three #201 asked for, plus binaries |
| Hidden files | codespell's default — dotfiles and dot-directories skipped | Keeps this to two new files. Turning `check-hidden` on adds one finding: `# Pheonix` above `PHOENIX_API_KEY` in `.env` |
| Version | pinned, `codespell==2.4.3` | A blocking check stays deterministic; an unpinned install can turn an untouched PR red on a dictionary update |
| Where the settings live | `.codespellrc`, not the workflow | CI runs a bare `codespell`, so `codespell` at the repo root is the same check locally |

A separate workflow rather than a job in `docs.yml`: that one is a deploy pipeline, and folding the
check in would mean adding a `pull_request` trigger, dropping its path filter, and sharing its
`concurrency: pages` group between PR runs and Pages deploys.

## Verification

```console
$ codespell                                       # 7cafc97 with this PR
$ echo $?
0

$ printf '\nThis sentance is wrong.\n' >> docs/index.md
$ codespell
./docs/index.md:109: sentance ==> sentence
$ echo $?
65

$ mkdir -p site node_modules/x
$ echo 'teh sentance occured' | tee site/i.html node_modules/x/a.js
teh sentance occured
$ codespell                                       # skip entries hold
$ echo $?
0
```

When the check fires on a future PR, the fix stays with the author: `codespell -w` rewrites the
unambiguous ones (5 of the 7 in #196, the other two had more than one candidate), the rest are a
hand edit, and a word the dictionary gets wrong goes into `ignore-words-list` in `.codespellrc` or
gets a `codespell:ignore` comment on that line. All three land in the same PR, so nothing waits on a
maintainer.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
